### PR TITLE
Change use of POSIX write() to send() which was causing silent crash of application

### DIFF
--- a/examples-h/listener.c
+++ b/examples-h/listener.c
@@ -1,0 +1,104 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include <stomp.h>
+
+struct ctx {
+    const char *destination;
+};
+
+static void dump_hdrs(int hdrc, const struct stomp_hdr *hdrs)
+{
+    int i;
+    for (i = 0; i < hdrc; i++) {
+        fprintf(stdout, "%s:%s\n", hdrs[i].key, hdrs[i].val);
+    }
+}
+
+static void _connected(stomp_session_t *s, void *ctx, void *session_ctx)
+{
+    struct ctx *c = session_ctx;
+
+    struct stomp_hdr opt_hdrs[] = {
+        {"selector", "target = 'mee'"},
+        {NULL, NULL},
+    };
+    int err = stomp_subscribe_h(s, c->destination, opt_hdrs);
+    if (err < 0) {
+        perror("stomp");
+    }
+}
+
+static void _message(stomp_session_t *s, void *ctx, void *session_ctx)
+{
+    struct stomp_ctx_message *e = ctx;
+    dump_hdrs(e->hdrc, e->hdrs);
+    fprintf(stdout, "message: %s\n", (const char *)e->body);
+}
+
+static void _error(stomp_session_t *session, void *ctx, void *session_ctx)
+{
+    struct stomp_ctx_error *e = ctx;
+    dump_hdrs(e->hdrc, e->hdrs);
+    fprintf(stderr, "err: %s\n", (const char *)e->body);
+}
+
+static void _receipt(stomp_session_t *s, void *ctx, void *session_ctx)
+{
+    struct stomp_ctx_receipt *e = ctx;
+    dump_hdrs(e->hdrc, e->hdrs);
+    fprintf(stdout, "receipt: \n");
+}
+
+static void _user(stomp_session_t *s, void *ctx, void *session_ctx)
+{
+    // called every heartbeet
+    fprintf(stdout, "hartbeet: %d\n", (int)clock());
+}
+
+int main(int argc, char *argv[])
+{
+    int err;
+    struct ctx c;
+    stomp_session_t *s;
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s <destination>\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+
+    c.destination = argv[1];
+
+    s = stomp_session_new(&c);
+    if (!s) {
+        perror("stomp");
+        exit(EXIT_FAILURE);
+    }
+
+    stomp_callback_set(s, SCB_CONNECTED, _connected);
+    stomp_callback_set(s, SCB_ERROR, _error);
+    stomp_callback_set(s, SCB_MESSAGE, _message);
+    stomp_callback_set(s, SCB_RECEIPT, _receipt);
+    stomp_callback_set(s, SCB_USER, _user);
+
+    err = stomp_connect_h(s, "localhost", "61613", NULL, "mybroker", "admin", "password", "5000,10000", NULL);
+    if (err) {
+        perror("stomp");
+        stomp_session_free(s);
+        exit(EXIT_FAILURE);
+    }
+
+    err = stomp_run(s);
+    if (err) {
+        perror("stomp");
+        stomp_session_free(s);
+        exit(EXIT_FAILURE);
+    }
+
+    stomp_session_free(s);
+
+    exit(EXIT_SUCCESS);
+}
+

--- a/examples-h/publisher.c
+++ b/examples-h/publisher.c
@@ -1,0 +1,56 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <stomp.h>
+
+
+int main(int argc, char *argv[])
+{
+    int err;
+    stomp_session_t *s;
+
+    // destination, msg
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s <destination> <message>\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+    const char *destination = argv[1];
+    const char *msg = argv[2];
+
+    // session initialize
+    s = stomp_session_new(NULL);
+    if (!s) {
+        perror("stomp");
+        exit(EXIT_FAILURE);
+    }
+
+    // connect
+    err = stomp_connect_h(s, "localhost", "61613", NULL, "mybroker", "admin", "password", NULL, NULL);
+    if (err) {
+        perror("stomp");
+        stomp_session_free(s);
+        exit(EXIT_FAILURE);
+    }
+
+    // send message
+    struct stomp_hdr opt_hdrs[] = {
+        {"target", "mee"},
+        {NULL, NULL},
+    };
+    err = stomp_send_h(s, destination, opt_hdrs, msg);
+    if (err) {
+        perror("stomp");
+        stomp_session_free(s);
+        exit(EXIT_FAILURE);
+    }
+
+    // disconnect
+
+    // clean
+    stomp_session_free(s);
+
+    // exit
+    exit(EXIT_SUCCESS);
+}
+

--- a/examples/publisher.c
+++ b/examples/publisher.c
@@ -1,0 +1,111 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <stomp.h>
+
+struct ctx {
+    const char *destination;
+};
+
+static void dump_hdrs(int hdrc, const struct stomp_hdr *hdrs)
+{
+    int i;
+    for (i = 0; i < hdrc; i++) {
+        fprintf(stdout, "%s:%s\n", hdrs[i].key, hdrs[i].val);
+    }
+}
+
+static void _connected(stomp_session_t *s, void *ctx, void *session_ctx)
+{
+    struct stomp_ctx_connected *e = ctx;
+    dump_hdrs(e->hdrc, e->hdrs);
+    fprintf(stdout, "connected: \n");
+}
+
+static void _message(stomp_session_t *s, void *ctx, void *session_ctx)
+{
+    struct stomp_ctx_message *e = ctx;
+    dump_hdrs(e->hdrc, e->hdrs);
+    fprintf(stdout, "message: %s\n", (const char *)e->body);
+}
+
+static void _error(stomp_session_t *session, void *ctx, void *session_ctx)
+{
+    struct stomp_ctx_error *e = ctx;
+    dump_hdrs(e->hdrc, e->hdrs);
+    fprintf(stderr, "err: %s\n", (const char *)e->body);
+}
+
+static void _receipt(stomp_session_t *s, void *ctx, void *session_ctx)
+{
+    struct stomp_ctx_receipt *e = ctx;
+    dump_hdrs(e->hdrc, e->hdrs);
+    fprintf(stdout, "receipt: \n");
+}
+
+static void _user(stomp_session_t *s, void *ctx, void *session_ctx)
+{
+}
+
+int main(int argc, char *argv[])
+{
+    int err;
+    struct ctx c;
+    stomp_session_t *s;
+
+    // destination
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s <destination>\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+    c.destination = argv[1];
+
+    // session initialize
+    s = stomp_session_new(&c);
+    if (!s) {
+        perror("stomp");
+        exit(EXIT_FAILURE);
+    }
+    stomp_callback_set(s, SCB_CONNECTED, _connected);
+    stomp_callback_set(s, SCB_ERROR, _error);
+    stomp_callback_set(s, SCB_MESSAGE, _message);
+    stomp_callback_set(s, SCB_RECEIPT, _receipt);
+    stomp_callback_set(s, SCB_USER, _user);
+
+    // connect
+    struct stomp_hdr conn_hdrs[] = {
+        {"login", "admin"},
+        {"passcode", "password"},
+        {"accept-version", "1.2"},
+        {"heart-beat", "1000,1000"},
+    };
+    err = stomp_connect(s, "127.0.0.1", "61613", sizeof(conn_hdrs) / sizeof(struct stomp_hdr), conn_hdrs);
+    if (err) {
+        perror("stomp");
+        stomp_session_free(s);
+        exit(EXIT_FAILURE);
+    }
+
+    // send message
+    struct stomp_hdr send_hdrs[] = {
+        {"destination", c.destination},
+        {"content-type", "text/plain"},
+    };
+    const char *send_body = "hello message from c";
+    err = stomp_send(s, sizeof(send_hdrs) / sizeof(struct stomp_hdr), send_hdrs, (void *)send_body, strlen(send_body));
+    if (err) {
+        perror("stomp");
+        stomp_session_free(s);
+        exit(EXIT_FAILURE);
+    }
+
+    // disconnect
+
+    // clean
+    stomp_session_free(s);
+
+    // exit
+    exit(EXIT_SUCCESS);
+}
+

--- a/src/err_r.c
+++ b/src/err_r.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 Larry Wu <rulerson@gmail.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stddef.h>
+#include <string.h>
+#include "err_r.h"
+
+static __thread const char *_errstr = NULL;
+
+void errstr_set(const char *errstr)
+{
+    _errstr = errstr;
+}
+
+const char *errstr_get()
+{
+    return _errstr;
+}
+

--- a/src/err_r.h
+++ b/src/err_r.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014 Larry Wu<rulerson@gmail.com>
+ *
+ *      2014-10-14   created     thread-safe error string, need gcc support, please ref here<https://gcc.gnu.org/onlinedocs/gcc-3.3/gcc/Thread-Local.html>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef ERR_R_H
+#define ERR_R_H
+
+void errstr_set(const char *errstr);
+const char *errstr_get();
+
+#endif /* ERR_R_H */

--- a/src/frame.c
+++ b/src/frame.c
@@ -24,756 +24,755 @@
 #include "hdr.h"
 
 enum read_state {
-	RS_INIT,
-	RS_CMD,
-	RS_HDR,
-	RS_HDR_ESC,
-	RS_BODY,
-	RS_DONE,
-	RS_ERR
+    RS_INIT,
+    RS_CMD,
+    RS_HDR,
+    RS_HDR_ESC,
+    RS_BODY,
+    RS_DONE,
+    RS_ERR
 };
 
 struct frame_hdr {
-	ptrdiff_t key_offset;
-	size_t key_len;
-	ptrdiff_t val_offset;
-	size_t val_len;
+    ptrdiff_t key_offset;
+    size_t key_len;
+    ptrdiff_t val_offset;
+    size_t val_len;
 };
 
 struct _frame {
-	void *buf;
-	size_t buf_len; /* length of data in buf in bytes */
-	size_t buf_capacity; /* allocated size in bytes */
+    void *buf;
+    size_t buf_len; /* length of data in buf in bytes */
+    size_t buf_capacity; /* allocated size in bytes */
 
-	ptrdiff_t cmd_offset; /* offset in buff to the start of the cmd string */
-	size_t cmd_len; /* lenght of cmd string in bytes */
+    ptrdiff_t cmd_offset; /* offset in buff to the start of the cmd string */
+    size_t cmd_len; /* lenght of cmd string in bytes */
 
-	struct frame_hdr *hdrs; /* array of struct frame_hdr elements */
-	size_t hdrs_len; /* number of elements in the array */
-	size_t hdrs_capacity; /* allocated number of struct frame_hdr elements */
+    struct frame_hdr *hdrs; /* array of struct frame_hdr elements */
+    size_t hdrs_len; /* number of elements in the array */
+    size_t hdrs_capacity; /* allocated number of struct frame_hdr elements */
 
-	struct stomp_hdr *stomp_hdrs; /* array of struct stomp_hdr elements */
-	size_t stomp_hdrs_len; /* number of elements in the array */
-	size_t stomp_hdrs_capacity; /* allocated number of struct stomp_hdr elements */
+    struct stomp_hdr *stomp_hdrs; /* array of struct stomp_hdr elements */
+    size_t stomp_hdrs_len; /* number of elements in the array */
+    size_t stomp_hdrs_capacity; /* allocated number of struct stomp_hdr elements */
 
-	ptrdiff_t body_offset; /* offset in buff to the start of the body */
-	size_t body_len; /* length of body in bytes */
+    ptrdiff_t body_offset; /* offset in buff to the start of the body */
+    size_t body_len; /* length of body in bytes */
 
-	enum read_state read_state; /* current state of the frame reading state mashine */
-	ptrdiff_t tmp_offset; /* current position within buf while reading an incomming frame */
-	size_t tmp_len; /* amount of bytes read while reading an incomming frame */
+    enum read_state read_state; /* current state of the frame reading state mashine */
+    ptrdiff_t tmp_offset; /* current position within buf while reading an incomming frame */
+    size_t tmp_len; /* amount of bytes read while reading an incomming frame */
 };
 
 /* number of bytes to increase session->buf by
  * when adding more data to the frame */
 #define BUFINCLEN 512
 
-/* number of struct stomp_hdr structures to add to session->hdrs 
+/* number of struct stomp_hdr structures to add to session->hdrs
  * when adding more data to the frame */
 #define HDRINCLEN 4
 
 static int parse_content_length(const char *s, size_t *len)
 {
-	size_t tmp_len;
-	char *endptr;
-	const char *nptr = s;
+    size_t tmp_len;
+    char *endptr;
+    const char *nptr = s;
 
-	if (!s) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!s) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	errno = 0;
-	tmp_len = strtoul(nptr, &endptr, 10);
-	if ((errno == ERANGE ) || (errno != 0 && tmp_len == 0)) {
-		errno = EINVAL;
-		return -1;
-	}
+    errno = 0;
+    tmp_len = strtoul(nptr, &endptr, 10);
+    if ((errno == ERANGE ) || (errno != 0 && tmp_len == 0)) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (endptr == nptr) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (endptr == nptr) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	*len = tmp_len;
+    *len = tmp_len;
 
-	return 0;
+    return 0;
 }
 
 
 frame_t *frame_new()
 {
-	frame_t *f = calloc(1, sizeof(*f));
-	
-	return f;
+    frame_t *f = calloc(1, sizeof(*f));
+
+    return f;
 }
 
 void frame_free(frame_t *f)
 {
-	free(f->stomp_hdrs);
-	free(f->hdrs);
-	free(f->buf);
-	free(f);
+    free(f->stomp_hdrs);
+    free(f->hdrs);
+    free(f->buf);
+    free(f);
 }
 
 void frame_reset(frame_t *f)
 {
-	void *buf = f->buf;
-	size_t capacity = f->buf_capacity;
-	struct frame_hdr *hdrs = f->hdrs;
-	size_t hdrs_capacity = f->hdrs_capacity;
-	struct stomp_hdr *stomp_hdrs = f->stomp_hdrs;
-	size_t stomp_hdrs_capacity = f->stomp_hdrs_capacity;
+    void *buf = f->buf;
+    size_t capacity = f->buf_capacity;
+    struct frame_hdr *hdrs = f->hdrs;
+    size_t hdrs_capacity = f->hdrs_capacity;
+    struct stomp_hdr *stomp_hdrs = f->stomp_hdrs;
+    size_t stomp_hdrs_capacity = f->stomp_hdrs_capacity;
 
-	memset(f, 0, sizeof(*f));
-	memset(hdrs, 0, sizeof(*hdrs)*hdrs_capacity);
-	memset(stomp_hdrs, 0, sizeof(*stomp_hdrs)*stomp_hdrs_capacity);
+    memset(f, 0, sizeof(*f));
+    memset(hdrs, 0, sizeof(*hdrs)*hdrs_capacity);
+    memset(stomp_hdrs, 0, sizeof(*stomp_hdrs)*stomp_hdrs_capacity);
 
-	f->buf = buf;
-	f->buf_capacity = capacity;
-	f->hdrs = hdrs;
-	f->hdrs_capacity = hdrs_capacity;
-	f->stomp_hdrs = stomp_hdrs;
-	f->stomp_hdrs_capacity = stomp_hdrs_capacity;
-	f->read_state = RS_INIT;
+    f->buf = buf;
+    f->buf_capacity = capacity;
+    f->hdrs = hdrs;
+    f->hdrs_capacity = hdrs_capacity;
+    f->stomp_hdrs = stomp_hdrs;
+    f->stomp_hdrs_capacity = stomp_hdrs_capacity;
+    f->read_state = RS_INIT;
 }
 
 static size_t buflene(const void *data, size_t len)
 {
-	char c;
-	size_t lene = 0;
-	size_t i;
+    char c;
+    size_t lene = 0;
+    size_t i;
 
-	for (i = 0; i < len; i++) {
-		c = *(char*)(data + i);
-		if (c == '\r' || c == '\n' || 
-		    c == ':' || c == '\\' ) {
-			lene += 2;
-		} else {
-			lene += 1;
-		}
-	}
+    for (i = 0; i < len; i++) {
+        c = *(char *)(data + i);
+        if (c == '\r' || c == '\n' ||
+                c == ':' || c == '\\' ) {
+            lene += 2;
+        } else {
+            lene += 1;
+        }
+    }
 
-	return lene;
+    return lene;
 }
 
 static void *frame_alloc(frame_t *f, size_t len)
 {
-	size_t capacity;
-	void *buf;
+    size_t capacity;
+    void *buf;
 
-	if (f->buf_capacity - f->buf_len >= len) {
-		return f->buf + f->buf_len;
-	}
+    if (f->buf_capacity - f->buf_len >= len) {
+        return f->buf + f->buf_len;
+    }
 
-	capacity = f->buf_capacity + BUFINCLEN;
-	buf = realloc(f->buf, capacity);
-	if (!buf) {
-		return NULL;
-	}
+    capacity = f->buf_capacity + BUFINCLEN;
+    buf = realloc(f->buf, capacity);
+    if (!buf) {
+        return NULL;
+    }
 
-	memset(buf + f->buf_len, 0, (capacity - f->buf_len));
+    memset(buf + f->buf_len, 0, (capacity - f->buf_len));
 
-	f->buf = buf;
-	f->buf_capacity = capacity;
+    f->buf = buf;
+    f->buf_capacity = capacity;
 
-	return f->buf + f->buf_len;
+    return f->buf + f->buf_len;
 }
 
 static void *frame_bufcat(frame_t *f, const void *data, size_t len)
 {
-	void *dest;
+    void *dest;
 
-	dest = frame_alloc(f, len);
-	if (!dest) {
-		return NULL;
-	}
-	
-	dest = memcpy(dest, data, len);
-	
-	f->buf_len += len;
+    dest = frame_alloc(f, len);
+    if (!dest) {
+        return NULL;
+    }
 
-	return dest;
+    dest = memcpy(dest, data, len);
+
+    f->buf_len += len;
+
+    return dest;
 }
 
 static void *frame_bufcate(frame_t *f, const void *data, size_t len)
 {
-	size_t i;
-	void *dest;
-	char c;
-	char *buf;
-	size_t buf_len;
-	size_t lene;
+    size_t i;
+    void *dest;
+    char c;
+    char *buf;
+    size_t buf_len;
+    size_t lene;
 
-	lene = buflene(data, len);
-	if (lene == len) {
-		return frame_bufcat(f, data, len);
-	}
+    lene = buflene(data, len);
+    if (lene == len) {
+        return frame_bufcat(f, data, len);
+    }
 
-	dest = frame_alloc(f, lene);
-	if (!dest) {
-		return NULL;
-	}
-	
-	for (i = 0; i < len; i++) {
-		c = *(char *)(data + i);
-		switch(c){
-			case '\r':
-				buf = "\\r";
-				buf_len = 2;
-				break;
-			case '\n':
-				buf = "\\n";
-				buf_len = 2;
-				break;
-			case ':':
-				buf = "\\c";
-				buf_len = 2;
-				break;
-			case '\\':
-				buf = "\\\\";
-				buf_len = 2;
-				break;
-			default:
-				buf = (char *)(data + i);
-				buf_len = 1;
-		}
+    dest = frame_alloc(f, lene);
+    if (!dest) {
+        return NULL;
+    }
 
-		memcpy(f->buf + f->buf_len, buf, buf_len);
-		f->buf_len += buf_len;
-	}
+    for (i = 0; i < len; i++) {
+        c = *(char *)(data + i);
+        switch(c) {
+        case '\r':
+            buf = "\\r";
+            buf_len = 2;
+            break;
+        case '\n':
+            buf = "\\n";
+            buf_len = 2;
+            break;
+        case ':':
+            buf = "\\c";
+            buf_len = 2;
+            break;
+        case '\\':
+            buf = "\\\\";
+            buf_len = 2;
+            break;
+        default:
+            buf = (char *)(data + i);
+            buf_len = 1;
+        }
 
-	return dest;
+        memcpy(f->buf + f->buf_len, buf, buf_len);
+        f->buf_len += buf_len;
+    }
+
+    return dest;
 }
 
 int frame_cmd_set(frame_t *f, const char *cmd)
 {
-	void *dest;
-	size_t len;
+    void *dest;
+    size_t len;
 
-	if (!f) {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	if (f->cmd_len) {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	if (!cmd) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!f) {
+        errno = EINVAL;
+        return -1;
+    }
 
-       	len = strlen(cmd);
-	if (!len) {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	dest = frame_bufcat(f, cmd, len);
-	if (!dest) {
-		return -1;
-	}
-	
-	f->cmd_offset = dest - f->buf;
-	f->cmd_len = len;
+    if (f->cmd_len) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (!frame_bufcat(f, "\n", 1)) {
-		return -1;
-	}
+    if (!cmd) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	return 0;
+    len = strlen(cmd);
+    if (!len) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    dest = frame_bufcat(f, cmd, len);
+    if (!dest) {
+        return -1;
+    }
+
+    f->cmd_offset = dest - f->buf;
+    f->cmd_len = len;
+
+    if (!frame_bufcat(f, "\n", 1)) {
+        return -1;
+    }
+
+    return 0;
 }
 
 int frame_hdr_add(frame_t *f, const char *key, const char *val)
 {
-	struct frame_hdr *h;
-	void *dest;
-	size_t key_len;
-	size_t val_len;
+    struct frame_hdr *h;
+    void *dest;
+    size_t key_len;
+    size_t val_len;
 
-	if (!f) {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	if (!f->cmd_len) {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	// TODO what about zero length body frames
-	if (f->body_offset) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!f) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (!key) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!f->cmd_len) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	key_len = strlen(key);
+    // TODO what about zero length body frames
+    if (f->body_offset) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (!key_len) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!key) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (!val) {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	val_len = strlen(val);
+    key_len = strlen(key);
 
-	if (!val_len) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!key_len) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (!val) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    val_len = strlen(val);
+
+    if (!val_len) {
+        errno = EINVAL;
+        return -1;
+    }
 
 
-	if (!(f->hdrs_capacity - f->hdrs_len)) {
-		size_t capacity = f->hdrs_capacity + HDRINCLEN;
-		h = realloc(f->hdrs, capacity * sizeof(*h));
-		if (!h) {
-			return -1;
-		}
-		
-		memset(&h[f->hdrs_len], 0, sizeof(*h)*(capacity - f->hdrs_len));
+    if (!(f->hdrs_capacity - f->hdrs_len)) {
+        size_t capacity = f->hdrs_capacity + HDRINCLEN;
+        h = realloc(f->hdrs, capacity * sizeof(*h));
+        if (!h) {
+            return -1;
+        }
 
-		f->hdrs = h;
-		f->hdrs_capacity = capacity;
-	}
+        memset(&h[f->hdrs_len], 0, sizeof(*h) * (capacity - f->hdrs_len));
 
-	h = &f->hdrs[f->hdrs_len];
-	dest = frame_bufcate(f, key, key_len);
-	if (!dest) {
-		return -1;
-	}
+        f->hdrs = h;
+        f->hdrs_capacity = capacity;
+    }
 
-	h->key_offset = dest - f->buf; 
+    h = &f->hdrs[f->hdrs_len];
+    dest = frame_bufcate(f, key, key_len);
+    if (!dest) {
+        return -1;
+    }
 
-	if (!frame_bufcat(f, ":", 1)) {
-		return -1;
-	}
+    h->key_offset = dest - f->buf;
 
-	dest = frame_bufcate(f, val, val_len);
-	if (!dest) {
-		return -1;
-	}
-	
-	h->val_offset = dest - f->buf;
+    if (!frame_bufcat(f, ":", 1)) {
+        return -1;
+    }
 
-	if (!frame_bufcat(f, "\n", 1)) {
-		return -1;
-	}
+    dest = frame_bufcate(f, val, val_len);
+    if (!dest) {
+        return -1;
+    }
 
-	f->hdrs_len += 1;
+    h->val_offset = dest - f->buf;
 
-	return 0;
+    if (!frame_bufcat(f, "\n", 1)) {
+        return -1;
+    }
+
+    f->hdrs_len += 1;
+
+    return 0;
 }
 
 int frame_hdrs_add(frame_t *f, size_t hdrc, const struct stomp_hdr *hdrs)
 {
-	size_t i;
-	const struct stomp_hdr *h;
+    size_t i;
+    const struct stomp_hdr *h;
 
-	if (!hdrs) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!hdrs) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	for (i=0; i < hdrc; i++) {
-		h = &hdrs[i];
-		if (frame_hdr_add(f, h->key, h->val)) {
-			return -1;
-		}
-	}
+    for (i = 0; i < hdrc; i++) {
+        h = &hdrs[i];
+        if (frame_hdr_add(f, h->key, h->val)) {
+            return -1;
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
 static size_t frame_hdr_get(frame_t *f, const char *key, const char **val)
 {
-	size_t i;
-	const struct frame_hdr *h;
-	for (i=0; i < f->hdrs_len; i++) {
-		h = &f->hdrs[i];
-		if (!strncmp(key, f->buf + h->key_offset, h->key_len)) {
-			*val = f->buf + h->val_offset;
-			return h->val_len; 
-		}
-	}
+    size_t i;
+    const struct frame_hdr *h;
+    for (i = 0; i < f->hdrs_len; i++) {
+        h = &f->hdrs[i];
+        if (!strncmp(key, f->buf + h->key_offset, h->key_len)) {
+            *val = f->buf + h->val_offset;
+            return h->val_len;
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
 
 int frame_body_set(frame_t *f, const void *data, size_t len)
 {
-	void *dest;
-	ptrdiff_t offset;
+    void *dest;
+    ptrdiff_t offset;
 
-	if (!f) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!f) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (!f->cmd_len) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!f->cmd_len) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (f->body_offset) {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	/* end of headers */ 
-	if (!frame_bufcat(f, "\n", 1)) {
-		return -1;
-	}
+    if (f->body_offset) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	dest = frame_bufcat(f, data, len);
-	if (!dest) {
-		return -1;
-	}
+    /* end of headers */
+    if (!frame_bufcat(f, "\n", 1)) {
+        return -1;
+    }
 
-	offset = dest - f->buf;
+    dest = frame_bufcat(f, data, len);
+    if (!dest) {
+        return -1;
+    }
 
-	/* end of frame */
-	if (!frame_bufcat(f, "\0", 1)) {
-		return -1;
-	}
+    offset = dest - f->buf;
 
-	f->body_offset = offset;
-	f->body_len = len;
+    /* end of frame */
+    if (!frame_bufcat(f, "\0", 1)) {
+        return -1;
+    }
 
-	return 0;
+    f->body_offset = offset;
+    f->body_len = len;
+
+    return 0;
 }
 
-static enum read_state frame_read_body(frame_t *f, char c) 
+static enum read_state frame_read_body(frame_t *f, char c)
 {
-	void *tmp;
-	enum read_state state = f->read_state;
-	size_t body_len;
-	const char *l;
+    void *tmp;
+    enum read_state state = f->read_state;
+    size_t body_len;
+    const char *l;
 
-	tmp = frame_bufcat(f, &c, 1);
-	if (!tmp) {
-		return RS_ERR;
-	}
+    tmp = frame_bufcat(f, &c, 1);
+    if (!tmp) {
+        return RS_ERR;
+    }
 
-	if (!f->tmp_offset) {
-		f->tmp_offset = tmp - f->buf;
-	}
+    if (!f->tmp_offset) {
+        f->tmp_offset = tmp - f->buf;
+    }
 
-	f->tmp_len += 1;
-	
-	if (c != '\0') {
-		return state;
-	}
-       	
-	/* \0 and no content-type -> frame is over */ 
-	/* OR err parsing content-type -> frame is over */ 
-	/* OR loaded all data -> frame is over */
-	if (!frame_hdr_get(f, "content-length", &l) || parse_content_length(l, &body_len) || f->tmp_len >= body_len){
-		f->body_offset = f->tmp_offset;
-		f->body_len = f->tmp_len - 1; /* skip last '\0' */
-		return RS_DONE;
-	}
+    f->tmp_len += 1;
 
-	return state;
-} 
+    if (c != '\0') {
+        return state;
+    }
 
-ssize_t frame_write(int fd, frame_t *f) 
-{
-	size_t left; 
-	ssize_t n;
-	ssize_t total = 0;
+    /* \0 and no content-type -> frame is over */
+    /* OR err parsing content-type -> frame is over */
+    /* OR loaded all data -> frame is over */
+    if (!frame_hdr_get(f, "content-length", &l) || parse_content_length(l, &body_len) || f->tmp_len >= body_len) {
+        f->body_offset = f->tmp_offset;
+        f->body_len = f->tmp_len - 1; /* skip last '\0' */
+        return RS_DONE;
+    }
 
-	/* close the frame */
-	if (!f->body_offset) {
-		if (!frame_bufcat(f, "\n\0", 2)) {
-			return -1;
-		}
-	}
-
-	left = f->buf_len; 
-	while(total < f->buf_len) {
-		n = write(fd, f->buf+total, left);
-		if (n == -1) {
-			return -1;
-		}
-
-		total += n;
-		left -= n;
-	}
-
-	return total; 
+    return state;
 }
 
-static enum read_state frame_read_init(frame_t *f, char c) 
+ssize_t frame_write(int fd, frame_t *f)
 {
-	void *tmp;
-	enum read_state state = f->read_state;
+    size_t left;
+    ssize_t n;
+    ssize_t total = 0;
 
-	switch (c) {
-		case 'C': /* CONNECTED */
-		case 'E': /* ERROR */
-		case 'R': /* RECEIPT */
-		case 'M': /* MESSAGE */
-			state = RS_ERR;
-			tmp = frame_bufcat(f, &c, 1);
-		       	if (tmp) {
-				state = RS_CMD;
-				f->tmp_offset = tmp - f->buf;
-				f->tmp_len = 1;
-			}
-			break;
-		case '\n': /* heart-beat */
-			state = RS_DONE;
-			break;
-		default:
-			;
-	}
+    /* close the frame */
+    if (!f->body_offset) {
+        if (!frame_bufcat(f, "\n\0", 2)) {
+            return -1;
+        }
+    }
 
-	return state;
-} 
+    left = f->buf_len;
+    while(total < f->buf_len) {
+        n = write(fd, f->buf + total, left);
+        if (n == -1) {
+            return -1;
+        }
 
-static enum read_state frame_read_cmd(frame_t *f, char c) 
+        total += n;
+        left -= n;
+    }
+
+    return total;
+}
+
+static enum read_state frame_read_init(frame_t *f, char c)
 {
-	enum read_state state = f->read_state;
-	
-	switch (c) {
-		case '\r': 
-			break;
-		case '\0':
-			state = RS_ERR;
-			break;
-		case '\n':
-			state = RS_ERR;
-			if (frame_bufcat(f, "\0", 1)) {
-				if (!strncmp(f->buf + f->tmp_offset, "CONNECTED", f->tmp_len) || 
-					!strncmp(f->buf + f->tmp_offset, "ERROR", f->tmp_len) || 
-					!strncmp(f->buf + f->tmp_offset, "RECEIPT", f->tmp_len) || 
-					!strncmp(f->buf + f->tmp_offset, "MESSAGE", f->tmp_len)) 
-				{
-					f->cmd_offset = f->tmp_offset;
-					f->cmd_len = f->tmp_len;
-					state = RS_HDR;
-					f->tmp_offset = 0;
-					f->tmp_len = 0;
-				} 
-			} 
-			break;
-		default:
-			if (!frame_bufcat(f, &c, 1)) {
-				state = RS_ERR;
-			} else {
-				f->tmp_len += 1;
-			}
-	}
+    void *tmp;
+    enum read_state state = f->read_state;
 
-	return state;
-} 
+    switch (c) {
+    case 'C': /* CONNECTED */
+    case 'E': /* ERROR */
+    case 'R': /* RECEIPT */
+    case 'M': /* MESSAGE */
+        state = RS_ERR;
+        tmp = frame_bufcat(f, &c, 1);
+        if (tmp) {
+            state = RS_CMD;
+            f->tmp_offset = tmp - f->buf;
+            f->tmp_len = 1;
+        }
+        break;
+    case '\n': /* heart-beat */
+        state = RS_DONE;
+        break;
+    default:
+        ;
+    }
 
-static enum read_state frame_read_hdr(frame_t *f, char c) 
+    return state;
+}
+
+static enum read_state frame_read_cmd(frame_t *f, char c)
 {
-	struct frame_hdr *h;
-	void *tmp;
-	size_t count = f->hdrs_len;
-	enum read_state state = f->read_state;
-	
-	if (!(f->hdrs_capacity - count)) {
-		size_t capacity = f->hdrs_capacity + HDRINCLEN;
-		h = realloc(f->hdrs, capacity * sizeof(*h));
-		if (!h) {
-			return RS_ERR;
-		}
+    enum read_state state = f->read_state;
 
-		memset(&h[count], 0, sizeof(*h)*(capacity - count));
+    switch (c) {
+    case '\r':
+        break;
+    case '\0':
+        state = RS_ERR;
+        break;
+    case '\n':
+        state = RS_ERR;
+        if (frame_bufcat(f, "\0", 1)) {
+            if (!strncmp(f->buf + f->tmp_offset, "CONNECTED", f->tmp_len) ||
+                    !strncmp(f->buf + f->tmp_offset, "ERROR", f->tmp_len) ||
+                    !strncmp(f->buf + f->tmp_offset, "RECEIPT", f->tmp_len) ||
+                    !strncmp(f->buf + f->tmp_offset, "MESSAGE", f->tmp_len)) {
+                f->cmd_offset = f->tmp_offset;
+                f->cmd_len = f->tmp_len;
+                state = RS_HDR;
+                f->tmp_offset = 0;
+                f->tmp_len = 0;
+            }
+        }
+        break;
+    default:
+        if (!frame_bufcat(f, &c, 1)) {
+            state = RS_ERR;
+        } else {
+            f->tmp_len += 1;
+        }
+    }
 
-		f->hdrs = h;
-		f->hdrs_capacity = capacity;
-	}
+    return state;
+}
 
-	h = &f->hdrs[f->hdrs_len];
-	
-	switch (c) {
-		case '\0':
-			state = RS_ERR;
-			break;
-		case '\r': 
-			break;
-		case ':':
-			if (!frame_bufcat(f, "\0", 1)) {
-				state = RS_ERR;
-			} else {
-				h->key_offset = f->tmp_offset;
-				h->key_len = f->tmp_len;
-				f->tmp_offset = 0;
-				f->tmp_len = 0;
-			}
-			break;
-		case '\n':
-			if (h->key_len) {
-				if (!frame_bufcat(f, "\0", 1)) {
-					state = RS_ERR;
-				} else {
-					h->val_offset = f->tmp_offset;
-					h->val_len = f->tmp_len;
-					f->hdrs_len += 1;
-					f->tmp_offset = 0;
-					f->tmp_len = 0;
-				}
-			} else {
-				state = RS_BODY;
-			} 
-			break;
-		case '\\':
-				state = RS_HDR_ESC;
-			break;
-		default:
-			tmp = frame_bufcat(f, &c, 1);
-			if (!tmp) {
-				state = RS_ERR;
-			} else {
-				if (!f->tmp_offset) {
-					f->tmp_offset = tmp - f->buf;
-				} 
-				f->tmp_len += 1;
-			}
-	}
-
-	return state;
-} 
-
-static enum read_state frame_read_hdr_esc(frame_t *f, char c) 
+static enum read_state frame_read_hdr(frame_t *f, char c)
 {
-	char *buf;
-	void *tmp;
-	
-	if (c == 'r') {
-		buf = "\r";
-	} else if (c == 'n') {
-		buf = "\n";
-	} else if (c == 'c') {
-		buf = ":";
-	} else if (c == '\\') {
-		buf = "\\";
-	} else {
-		return RS_ERR;
-	}
+    struct frame_hdr *h;
+    void *tmp;
+    size_t count = f->hdrs_len;
+    enum read_state state = f->read_state;
 
-	tmp = frame_bufcat(f, buf, 1);
-	if (!tmp) {
-		return RS_ERR;
-	} 
+    if (!(f->hdrs_capacity - count)) {
+        size_t capacity = f->hdrs_capacity + HDRINCLEN;
+        h = realloc(f->hdrs, capacity * sizeof(*h));
+        if (!h) {
+            return RS_ERR;
+        }
 
-	if (!f->tmp_offset) {
-		f->tmp_offset = tmp - f->buf;
-	} 
+        memset(&h[count], 0, sizeof(*h) * (capacity - count));
 
-	f->tmp_len += 1;
+        f->hdrs = h;
+        f->hdrs_capacity = capacity;
+    }
 
-	return RS_HDR;
-} 
+    h = &f->hdrs[f->hdrs_len];
+
+    switch (c) {
+    case '\0':
+        state = RS_ERR;
+        break;
+    case '\r':
+        break;
+    case ':':
+        if (!frame_bufcat(f, "\0", 1)) {
+            state = RS_ERR;
+        } else {
+            h->key_offset = f->tmp_offset;
+            h->key_len = f->tmp_len;
+            f->tmp_offset = 0;
+            f->tmp_len = 0;
+        }
+        break;
+    case '\n':
+        if (h->key_len) {
+            if (!frame_bufcat(f, "\0", 1)) {
+                state = RS_ERR;
+            } else {
+                h->val_offset = f->tmp_offset;
+                h->val_len = f->tmp_len;
+                f->hdrs_len += 1;
+                f->tmp_offset = 0;
+                f->tmp_len = 0;
+            }
+        } else {
+            state = RS_BODY;
+        }
+        break;
+    case '\\':
+        state = RS_HDR_ESC;
+        break;
+    default:
+        tmp = frame_bufcat(f, &c, 1);
+        if (!tmp) {
+            state = RS_ERR;
+        } else {
+            if (!f->tmp_offset) {
+                f->tmp_offset = tmp - f->buf;
+            }
+            f->tmp_len += 1;
+        }
+    }
+
+    return state;
+}
+
+static enum read_state frame_read_hdr_esc(frame_t *f, char c)
+{
+    char *buf;
+    void *tmp;
+
+    if (c == 'r') {
+        buf = "\r";
+    } else if (c == 'n') {
+        buf = "\n";
+    } else if (c == 'c') {
+        buf = ":";
+    } else if (c == '\\') {
+        buf = "\\";
+    } else {
+        return RS_ERR;
+    }
+
+    tmp = frame_bufcat(f, buf, 1);
+    if (!tmp) {
+        return RS_ERR;
+    }
+
+    if (!f->tmp_offset) {
+        f->tmp_offset = tmp - f->buf;
+    }
+
+    f->tmp_len += 1;
+
+    return RS_HDR;
+}
 
 int frame_read(int fd, frame_t *f)
 {
-	char c = 0;
-	
-	while (f->read_state != RS_ERR && f->read_state != RS_DONE) {
+    char c = 0;
 
-		if(read(fd, &c, sizeof(char)) != sizeof(char)) {
-			return -1;
-		}
+    while (f->read_state != RS_ERR && f->read_state != RS_DONE) {
 
-		switch(f->read_state) {
-			case RS_INIT:
-				f->read_state = frame_read_init(f, c);
-				break;
-			case RS_CMD:
-				f->read_state = frame_read_cmd(f, c);
-				break;
-			case RS_HDR:
-				f->read_state = frame_read_hdr(f, c);
-				break;
-			case RS_HDR_ESC:
-				f->read_state = frame_read_hdr_esc(f, c);
-				break;
-			case RS_BODY:
-				f->read_state = frame_read_body(f, c);
-				break;
-			default:
-				return -1;
-		}
-	}
-	
-	if (f->read_state == RS_ERR) {
-		return -1;
-	}
+        if(read(fd, &c, sizeof(char)) != sizeof(char)) {
+            return -1;
+        }
 
-	return 0;
+        switch(f->read_state) {
+        case RS_INIT:
+            f->read_state = frame_read_init(f, c);
+            break;
+        case RS_CMD:
+            f->read_state = frame_read_cmd(f, c);
+            break;
+        case RS_HDR:
+            f->read_state = frame_read_hdr(f, c);
+            break;
+        case RS_HDR_ESC:
+            f->read_state = frame_read_hdr_esc(f, c);
+            break;
+        case RS_BODY:
+            f->read_state = frame_read_body(f, c);
+            break;
+        default:
+            return -1;
+        }
+    }
+
+    if (f->read_state == RS_ERR) {
+        return -1;
+    }
+
+    return 0;
 }
 
 size_t frame_cmd_get(frame_t *f, const char **cmd)
 {
-	if (!f->cmd_len) {
-		return 0;
-	}
+    if (!f->cmd_len) {
+        return 0;
+    }
 
-	*cmd = f->buf + f->cmd_offset;
-	return f->cmd_len;
+    *cmd = f->buf + f->cmd_offset;
+    return f->cmd_len;
 }
 
 size_t frame_hdrs_get(frame_t *f, const struct stomp_hdr **hdrs)
 {
-	struct stomp_hdr *h;
-	size_t i;
+    struct stomp_hdr *h;
+    size_t i;
 
-	if (!f->hdrs) {
-		return 0;
-	}
+    if (!f->hdrs) {
+        return 0;
+    }
 
-	if (f->stomp_hdrs_len == f->hdrs_len) {
-		*hdrs = f->stomp_hdrs;
-		return f->stomp_hdrs_len;
-	}
+    if (f->stomp_hdrs_len == f->hdrs_len) {
+        *hdrs = f->stomp_hdrs;
+        return f->stomp_hdrs_len;
+    }
 
-	if (f->hdrs_len > f->stomp_hdrs_capacity) {
-		h = realloc(f->stomp_hdrs, f->hdrs_len * sizeof(*h));
-		if (!h) {
-			return -1;
-		}
-		
-		f->stomp_hdrs = h;
-		f->stomp_hdrs_capacity = f->hdrs_len;
-	}
+    if (f->hdrs_len > f->stomp_hdrs_capacity) {
+        h = realloc(f->stomp_hdrs, f->hdrs_len * sizeof(*h));
+        if (!h) {
+            return -1;
+        }
 
-	for (i=0; i < f->hdrs_len; i++) {
-		h = &f->stomp_hdrs[i];
-		h->key = f->buf + f->hdrs[i].key_offset;
-		h->val = f->buf + f->hdrs[i].val_offset;
-	}
+        f->stomp_hdrs = h;
+        f->stomp_hdrs_capacity = f->hdrs_len;
+    }
 
-	f->stomp_hdrs_len = f->hdrs_len;
+    for (i = 0; i < f->hdrs_len; i++) {
+        h = &f->stomp_hdrs[i];
+        h->key = f->buf + f->hdrs[i].key_offset;
+        h->val = f->buf + f->hdrs[i].val_offset;
+    }
 
-	*hdrs = f->stomp_hdrs;
-	return f->stomp_hdrs_len;
+    f->stomp_hdrs_len = f->hdrs_len;
+
+    *hdrs = f->stomp_hdrs;
+    return f->stomp_hdrs_len;
 }
 
 size_t frame_body_get(frame_t *f, const void **body)
 {
-	if (!f->body_len) {
-		return 0;
-	}
+    if (!f->body_len) {
+        return 0;
+    }
 
-	*body = f->buf + f->body_offset;
-	return f->body_len;
+    *body = f->buf + f->body_offset;
+    return f->body_len;
 }
 

--- a/src/frame.c
+++ b/src/frame.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
+#include <sys/socket.h>
 
 #include "frame.h"
 #include "hdr.h"
@@ -504,7 +505,7 @@ ssize_t frame_write(int fd, frame_t *f)
 
     left = f->buf_len;
     while(total < f->buf_len) {
-        n = write(fd, f->buf + total, left);
+        n = send(fd, f->buf + total, left, MSG_NOSIGNAL);
         if (n == -1) {
             return -1;
         }
@@ -775,4 +776,3 @@ size_t frame_body_get(frame_t *f, const void **body)
     *body = f->buf + f->body_offset;
     return f->body_len;
 }
-

--- a/src/stomp.c
+++ b/src/stomp.c
@@ -1,6 +1,8 @@
 /*
  * Copyright 2013 Evgeni Dobrev <evgeni_dobrev@developer.bg>
  *
+ *      2014-10-14   modify    Larry Wu<rulerson@gmail.com>    add some heper functions
+ *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -28,6 +30,8 @@
 #include "stomp.h"
 #include "frame.h"
 #include "hdr.h"
+#include "err_r.h"
+
 
 /* enough space for ULLONG_MAX as string */
 #define MAXBUFLEN 25
@@ -35,818 +39,992 @@
 /* max number of broker heartbeat timeouts */
 #define MAXBROKERTMOUTS 5
 
+/* max number of headers */
+#define MAX_NUM_HEADER 20
+
 
 enum stomp_prot {
-	SPL_10,
-	SPL_11,
-	SPL_12
+    SPL_10,
+    SPL_11,
+    SPL_12
 };
 
 struct stomp_callbacks {
-	void(*connected)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
-	void(*message)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
-	void(*error)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
-	void(*receipt)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
-	void(*user)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
+    void(*connected)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
+    void(*message)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
+    void(*error)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
+    void(*receipt)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
+    void(*user)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
 };
 
 struct _stomp_session {
-	struct stomp_callbacks callbacks; /* event callbacks */
-	void *ctx; /* pointer to user supplied session context */
+    struct stomp_callbacks callbacks; /* event callbacks */
+    void *ctx; /* pointer to user supplied session context */
 
-	frame_t *frame_out; /* library -> broker */
-	frame_t *frame_in; /* broker -> library */
+    frame_t *frame_out; /* library -> broker */
+    frame_t *frame_in; /* broker -> library */
 
-	enum stomp_prot protocol;
-	int broker_fd;
-	int client_id; /* unique ids for subscribe */
-	unsigned long client_hb; /* client heart beat period in milliseconds */
-	unsigned long broker_hb; /* broker heart beat period in milliseconds */
-	struct timespec last_write;
-	struct timespec last_read;
-	int broker_timeouts; 
-	int run;
+    enum stomp_prot protocol;
+    int broker_fd;
+    int client_id; /* unique ids for subscribe */
+    unsigned long client_hb; /* client heart beat period in milliseconds */
+    unsigned long broker_hb; /* broker heart beat period in milliseconds */
+    struct timespec last_write;
+    struct timespec last_read;
+    int broker_timeouts;
+    int run;
 };
 
 static int parse_version(const char *s, enum stomp_prot *v)
 {
-	enum stomp_prot tmp_v;
+    enum stomp_prot tmp_v;
 
-	if (!s) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!s) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (!strncmp(s, "1.2", 3)) {
-		tmp_v = SPL_12;
-	} else if (!strncmp(s, "1.1", 3)) {
-		tmp_v = SPL_11;
-	} else if (!strncmp(s, "1.0", 3)) {
-		tmp_v = SPL_10;
-	} else {
-		tmp_v = SPL_10;
-	}
-	
-	*v = tmp_v;
+    if (!strncmp(s, "1.2", 3)) {
+        tmp_v = SPL_12;
+    } else if (!strncmp(s, "1.1", 3)) {
+        tmp_v = SPL_11;
+    } else if (!strncmp(s, "1.0", 3)) {
+        tmp_v = SPL_10;
+    } else {
+        tmp_v = SPL_10;
+    }
 
-	return 0;
+    *v = tmp_v;
+
+    return 0;
 }
 static int parse_heartbeat(const char *s, unsigned long *x, unsigned long *y)
 {
-	unsigned long tmp_x, tmp_y;
-	char *endptr;
-	const char *nptr = s;
+    unsigned long tmp_x, tmp_y;
+    char *endptr;
+    const char *nptr = s;
 
-	if (!s) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!s) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	errno = 0;
-	tmp_x = strtoul(nptr, &endptr, 10);
-	if (errno != 0) {
-		errno = EINVAL;
-		return -1;
-	}
+    errno = 0;
+    tmp_x = strtoul(nptr, &endptr, 10);
+    if (errno != 0) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (tmp_x < 0) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (tmp_x < 0) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (endptr == nptr) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (endptr == nptr) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (*endptr != ',') {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	nptr = endptr;
-	nptr++;
+    if (*endptr != ',') {
+        errno = EINVAL;
+        return -1;
+    }
 
-	errno = 0;
-	tmp_y = strtoul(nptr, &endptr, 10);
-	if (errno !=0) {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	if (tmp_y < 0) {
-		errno = EINVAL;
-		return -1;
-	}
+    nptr = endptr;
+    nptr++;
 
-	if (endptr == nptr) {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	*x = tmp_x;
-	*y = tmp_y;
+    errno = 0;
+    tmp_y = strtoul(nptr, &endptr, 10);
+    if (errno != 0) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	return 0;
+    if (tmp_y < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (endptr == nptr) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *x = tmp_x;
+    *y = tmp_y;
+
+    return 0;
 }
 
 stomp_session_t *stomp_session_new(void *session_ctx)
 {
-	stomp_session_t *s = calloc(1, sizeof(*s));
-	if (!s) {
-		return NULL;
-	}
+    stomp_session_t *s = calloc(1, sizeof(*s));
+    if (!s) {
+        return NULL;
+    }
 
-	s->ctx = session_ctx;
-	s->broker_fd = -1;
+    s->ctx = session_ctx;
+    s->broker_fd = -1;
 
-	s->frame_out = frame_new();
-	if (!s->frame_out) {
-		free(s);
-	}
+    s->frame_out = frame_new();
+    if (!s->frame_out) {
+        free(s);
+    }
 
-	s->frame_in = frame_new();
-	if (!s->frame_in) {
-		free(s->frame_out);
-		free(s);
-	}
+    s->frame_in = frame_new();
+    if (!s->frame_in) {
+        free(s->frame_out);
+        free(s);
+    }
 
-	return s;
+    return s;
 }
 
 void stomp_session_free(stomp_session_t *s)
 {
-	frame_free(s->frame_out);
-	frame_free(s->frame_in);
-	free(s);
+    frame_free(s->frame_out);
+    frame_free(s->frame_in);
+    free(s);
 }
 
 void stomp_callback_set(stomp_session_t *s, enum stomp_cb_type type, stomp_cb_t cb)
 {
-	if (!s) {
-		return;
-	}
+    if (!s) {
+        return;
+    }
 
-	switch (type) {
-		case SCB_CONNECTED:
-			s->callbacks.connected = cb;
-			break;
-		case SCB_ERROR:
-			s->callbacks.error = cb;
-			break;
-		case SCB_MESSAGE:
-			s->callbacks.message = cb;
-			break;
-		case SCB_RECEIPT:
-			s->callbacks.receipt = cb;
-			break;
-		case SCB_USER:
-			s->callbacks.user = cb;
-		default:
-			return;
-	}
+    switch (type) {
+    case SCB_CONNECTED:
+        s->callbacks.connected = cb;
+        break;
+    case SCB_ERROR:
+        s->callbacks.error = cb;
+        break;
+    case SCB_MESSAGE:
+        s->callbacks.message = cb;
+        break;
+    case SCB_RECEIPT:
+        s->callbacks.receipt = cb;
+        break;
+    case SCB_USER:
+        s->callbacks.user = cb;
+    default:
+        return;
+    }
 }
 
 void stomp_callback_del(stomp_session_t *s, enum stomp_cb_type type)
 {
-	if (!s) {
-		return;
-	}
+    if (!s) {
+        return;
+    }
 
-	switch (type) {
-		case SCB_CONNECTED:
-			s->callbacks.connected = NULL;
-			break;
-		case SCB_ERROR:
-			s->callbacks.error = NULL;
-			break;
-		case SCB_MESSAGE:
-			s->callbacks.message = NULL;
-			break;
-		case SCB_RECEIPT:
-			s->callbacks.receipt = NULL;
-			break;
-		case SCB_USER:
-			s->callbacks.user = NULL;
-		default:
-			return;
-	}
+    switch (type) {
+    case SCB_CONNECTED:
+        s->callbacks.connected = NULL;
+        break;
+    case SCB_ERROR:
+        s->callbacks.error = NULL;
+        break;
+    case SCB_MESSAGE:
+        s->callbacks.message = NULL;
+        break;
+    case SCB_RECEIPT:
+        s->callbacks.receipt = NULL;
+        break;
+    case SCB_USER:
+        s->callbacks.user = NULL;
+    default:
+        return;
+    }
 }
 
 
 int stomp_connect(stomp_session_t *s, const char *host, const char *service, size_t hdrc, const struct stomp_hdr *hdrs)
 {
-	struct addrinfo hints;
-	struct addrinfo *result, *rp;
-	int sfd;
-	int err;
-	unsigned long x = 0;
-	unsigned long y = 0;
-	const char *hb = hdr_get(hdrc, hdrs, "heart-beat");
+    struct addrinfo hints;
+    struct addrinfo *result, *rp;
+    int sfd;
+    int err;
+    unsigned long x = 0;
+    unsigned long y = 0;
+    const char *hb = hdr_get(hdrc, hdrs, "heart-beat");
 
-	if (hb && parse_heartbeat(hb, &x, &y)) {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	memset(&hints, 0, sizeof(struct addrinfo));
-	hints.ai_family = AF_UNSPEC;
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_flags = 0;
-	hints.ai_protocol = 0;
+    if (hb && parse_heartbeat(hb, &x, &y)) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	err = getaddrinfo(host, service, &hints, &result);
-	if (err != 0) {
-		return -1;
-	}
+    memset(&hints, 0, sizeof(struct addrinfo));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = 0;
+    hints.ai_protocol = 0;
 
-	for (rp = result; rp != NULL; rp = rp->ai_next) {
-		sfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-		if (sfd == -1)
-			continue;
+    err = getaddrinfo(host, service, &hints, &result);
+    if (err != 0) {
+        return -1;
+    }
 
-		if (connect(sfd, rp->ai_addr, rp->ai_addrlen) != -1)
-			break; 
+    for (rp = result; rp != NULL; rp = rp->ai_next) {
+        sfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (sfd == -1)
+            continue;
 
-		close(sfd);
-	}
+        if (connect(sfd, rp->ai_addr, rp->ai_addrlen) != -1)
+            break;
+
+        close(sfd);
+    }
 
 
-	if (rp == NULL) { 
-		freeaddrinfo(result);
-		return -1;
-	}
-	
-	freeaddrinfo(result);
+    if (rp == NULL) {
+        freeaddrinfo(result);
+        return -1;
+    }
 
-	s->broker_fd = sfd;
-	s->run = 1;
-	
-	frame_reset(s->frame_out);
+    freeaddrinfo(result);
 
-	if (frame_cmd_set(s->frame_out, "CONNECT")) {
-		return -1;
-	}
-	
-	s->client_hb = x;
-	s->broker_hb = y;
-	
-	if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
-		return -1;
-	}
+    s->broker_fd = sfd;
+    s->run = 1;
 
-	if (frame_write(sfd, s->frame_out) < 0) {
-		s->run = 0;
-		return -1;
-	}
+    frame_reset(s->frame_out);
 
-	clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+    if (frame_cmd_set(s->frame_out, "CONNECT")) {
+        return -1;
+    }
 
-	return 0;
+    s->client_hb = x;
+    s->broker_hb = y;
+
+    if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
+        return -1;
+    }
+
+    if (frame_write(sfd, s->frame_out) < 0) {
+        s->run = 0;
+        return -1;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+
+    return 0;
 }
+
+int stomp_connect_h(stomp_session_t *s,
+                    const char *host,
+                    const char *service,
+                    const char *accept_version,
+                    const char *v_host,
+                    const char *login,
+                    const char *passcode,
+                    const char *heart_beat,
+                    const struct stomp_hdr *optional_hdrs
+                   )
+{
+    if (!s) {
+        errstr_set("null param 's'");
+        return -1;
+    }
+
+    // auto
+    if (!host)      host = "localhost";
+    if (!service)   service = "61613";
+
+    // constuct hdrs
+    struct stomp_hdr hdrs[MAX_NUM_HEADER];
+    size_t hdr_i = 0;
+    memset(hdrs, 0, sizeof(hdrs));
+    hdrs[hdr_i++] = (struct stomp_hdr) {"accept-version", accept_version ? accept_version : "1.2"};
+    hdrs[hdr_i++] = (struct stomp_hdr) {"login", login ? login : "admin"};
+    hdrs[hdr_i++] = (struct stomp_hdr) {"passcode", passcode ? passcode : "password"};
+    hdrs[hdr_i++] = (struct stomp_hdr) {"heart-beat", heart_beat ? heart_beat : "5000,10000"};
+    if(v_host) {
+        hdrs[hdr_i++] = (struct stomp_hdr) {"host", v_host};
+    }
+
+    if (optional_hdrs) {
+        const struct stomp_hdr *opt_hdr = optional_hdrs;
+        while (opt_hdr->key && hdr_i < MAX_NUM_HEADER) {
+            hdrs[hdr_i++] = (struct stomp_hdr) {
+                opt_hdr->key, opt_hdr->val
+            };
+            opt_hdr++;
+        }
+    }
+
+    // delegate
+    return stomp_connect(s, host, service, hdr_i, hdrs);
+}
+
 
 int stomp_disconnect(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs)
 {
-	frame_reset(s->frame_out);
+    frame_reset(s->frame_out);
 
-	if (frame_cmd_set(s->frame_out, "DISCONNECT")) {
-		return -1;
-	}
+    if (frame_cmd_set(s->frame_out, "DISCONNECT")) {
+        return -1;
+    }
 
-	if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
-		return -1;
-	}
+    if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
+        return -1;
+    }
 
-	if (frame_write(s->broker_fd, s->frame_out) < 0) {
-		s->run = 0;
-		return -1;
-	}
-	
-	clock_gettime(CLOCK_MONOTONIC, &s->last_write);
-	
-	return 0;
+    if (frame_write(s->broker_fd, s->frame_out) < 0) {
+        s->run = 0;
+        return -1;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+
+    return 0;
 }
+
+int stomp_disconnect_h(stomp_session_t *s,
+                       const struct stomp_hdr *optional_hdrs)
+{
+    // constuct hdrs
+    struct stomp_hdr hdrs[MAX_NUM_HEADER];
+    size_t hdr_i = 0;
+    memset(hdrs, 0, sizeof(hdrs));
+
+    if (optional_hdrs) {
+        const struct stomp_hdr *opt_hdr = optional_hdrs;
+        while (opt_hdr->key && hdr_i < MAX_NUM_HEADER) {
+            hdrs[hdr_i++] = (struct stomp_hdr) {
+                opt_hdr->key, opt_hdr->val
+            };
+            opt_hdr++;
+        }
+    }
+
+    // delegate
+    return stomp_disconnect(s, hdr_i, hdrs);
+}
+
 
 // TODO enforce different client-ids in case they are provided with hdrs
 int stomp_subscribe(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs)
 {
-	const char *ack;
-	char buf[MAXBUFLEN];
-	int client_id = 0;
+    const char *ack;
+    char buf[MAXBUFLEN];
+    int client_id = 0;
 
-	if (!hdr_get(hdrc, hdrs, "destination")) {
-		errno = EINVAL;
-		return -1;
-	}
-	
-	ack = hdr_get(hdrc, hdrs, "ack");
-	if (ack && strcmp(ack, "auto") && strcmp(ack, "client") && strcmp(ack, "client-individual")) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!hdr_get(hdrc, hdrs, "destination")) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	frame_reset(s->frame_out);
+    ack = hdr_get(hdrc, hdrs, "ack");
+    if (ack && strcmp(ack, "auto") && strcmp(ack, "client") && strcmp(ack, "client-individual")) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	if (frame_cmd_set(s->frame_out, "SUBSCRIBE")) {
-		return -1;
-	}
-	
-	if (!hdr_get(hdrc, hdrs, "id")) {
-		client_id = s->client_id;
-		if (client_id == INT_MAX) {
-			client_id = 0;
-		}
-		client_id++;
-		snprintf(buf, MAXBUFLEN, "%d", client_id);
-		if (frame_hdr_add(s->frame_out, "id", buf)) {
-			return -1;
-		}
-	} 
+    frame_reset(s->frame_out);
 
-	
-	if (!ack && frame_hdr_add(s->frame_out, "ack", "auto")) {
-		return -1;
-	}
-	
-	if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
-		return -1;
-	}
-	
-	if (frame_write(s->broker_fd, s->frame_out) < 0) {
-		s->run = 0;
-		return -1;
-	}
+    if (frame_cmd_set(s->frame_out, "SUBSCRIBE")) {
+        return -1;
+    }
 
-	clock_gettime(CLOCK_MONOTONIC, &s->last_write);
-	s->client_id = client_id;
+    if (!hdr_get(hdrc, hdrs, "id")) {
+        client_id = s->client_id;
+        if (client_id == INT_MAX) {
+            client_id = 0;
+        }
+        client_id++;
+        snprintf(buf, MAXBUFLEN, "%d", client_id);
+        if (frame_hdr_add(s->frame_out, "id", buf)) {
+            return -1;
+        }
+    }
 
-	return client_id;
+
+    if (!ack && frame_hdr_add(s->frame_out, "ack", "auto")) {
+        return -1;
+    }
+
+    if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
+        return -1;
+    }
+
+    if (frame_write(s->broker_fd, s->frame_out) < 0) {
+        s->run = 0;
+        return -1;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+    s->client_id = client_id;
+
+    return client_id;
 }
+
+int stomp_subscribe_h2(stomp_session_t *s,
+                       const char *id,
+                       const char *destination,
+                       const char *ack,
+                       const struct stomp_hdr *optional_hdrs)
+{
+    if (!s) {
+        errstr_set("null param 's'");
+        return -1;
+    }
+
+    if (!destination) {
+        errstr_set("null param 'destination'");
+        return -1;
+    }
+
+    // constuct hdrs
+    struct stomp_hdr hdrs[MAX_NUM_HEADER];
+    size_t hdr_i = 0;
+    memset(hdrs, 0, sizeof(hdrs));
+
+    if(id) {
+        hdrs[hdr_i++] = (struct stomp_hdr) {"id", id};
+    }
+
+    hdrs[hdr_i++] = (struct stomp_hdr) {"destination", destination};
+
+    if(ack) {
+        hdrs[hdr_i++] = (struct stomp_hdr) {"ack", ack};
+    }
+
+    if (optional_hdrs) {
+        const struct stomp_hdr *opt_hdr = optional_hdrs;
+        while (opt_hdr->key && hdr_i < MAX_NUM_HEADER) {
+            hdrs[hdr_i++] = (struct stomp_hdr) {
+                opt_hdr->key, opt_hdr->val
+            };
+            opt_hdr++;
+        }
+    }
+
+    // delegate
+    return stomp_subscribe(s, hdr_i, hdrs);
+}
+
+int stomp_subscribe_h(stomp_session_t *s,
+                      const char *destination,
+                      const struct stomp_hdr *optional_hdrs)
+{
+    return stomp_subscribe_h2(s, NULL, destination, NULL, optional_hdrs);
+}
+
 
 int stomp_unsubscribe(stomp_session_t *s, int client_id, size_t hdrc, const struct stomp_hdr *hdrs)
 {
-	char buf[MAXBUFLEN];
-	const char *id = hdr_get(hdrc, hdrs, "id");
-	const char *destination = hdr_get(hdrc, hdrs, "destination");
+    char buf[MAXBUFLEN];
+    const char *id = hdr_get(hdrc, hdrs, "id");
+    const char *destination = hdr_get(hdrc, hdrs, "destination");
 
-	if (s->protocol == SPL_10) {
-		if (!destination && !id && !client_id) {
-			errno = EINVAL;
-			return -1;
-		}
-	} else {
-		if (!id && !client_id) {
-			errno = EINVAL;
-			return -1;
-		}
-	}
+    if (s->protocol == SPL_10) {
+        if (!destination && !id && !client_id) {
+            errno = EINVAL;
+            return -1;
+        }
+    } else {
+        if (!id && !client_id) {
+            errno = EINVAL;
+            return -1;
+        }
+    }
 
-	frame_reset(s->frame_out);
+    frame_reset(s->frame_out);
 
-	if (frame_cmd_set(s->frame_out, "UNSUBSCRIBE")) {
-		return -1;
-	}
-	
-	// user provided client id. overrride all other supplied headers
-	if (client_id) {
-		snprintf(buf, MAXBUFLEN, "%lu", (unsigned long)client_id);
-		if (frame_hdr_add(s->frame_out, "id", buf)) {
-			return -1;
-		}
-	}
-	
-	if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
-		return -1;
-	}
+    if (frame_cmd_set(s->frame_out, "UNSUBSCRIBE")) {
+        return -1;
+    }
 
-	if (frame_write(s->broker_fd, s->frame_out) < 0) {
-		s->run = 0;
-		return -1;
-	}
-	
-	clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+    // user provided client id. overrride all other supplied headers
+    if (client_id) {
+        snprintf(buf, MAXBUFLEN, "%lu", (unsigned long)client_id);
+        if (frame_hdr_add(s->frame_out, "id", buf)) {
+            return -1;
+        }
+    }
 
-	return 0;
+    if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
+        return -1;
+    }
+
+    if (frame_write(s->broker_fd, s->frame_out) < 0) {
+        s->run = 0;
+        return -1;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+
+    return 0;
 }
 
 // TODO enforce different tx_ids
 int stomp_begin(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs)
 {
-	if (!hdr_get(hdrc, hdrs, "transaction")) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!hdr_get(hdrc, hdrs, "transaction")) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	frame_reset(s->frame_out);
+    frame_reset(s->frame_out);
 
-	if (frame_cmd_set(s->frame_out, "BEGIN")) {
-		return -1;
-	}
+    if (frame_cmd_set(s->frame_out, "BEGIN")) {
+        return -1;
+    }
 
-	if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
-		return -1;
-	}
-	
-	if (frame_write(s->broker_fd, s->frame_out) < 0) {
-		s->run = 0;
-		return -1;
-	}
-	
-	clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+    if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
+        return -1;
+    }
 
-	return 0;
+    if (frame_write(s->broker_fd, s->frame_out) < 0) {
+        s->run = 0;
+        return -1;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+
+    return 0;
 }
 
 int stomp_abort(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs)
 {
-	if (!hdr_get(hdrc, hdrs, "transaction")) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!hdr_get(hdrc, hdrs, "transaction")) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	frame_reset(s->frame_out);
+    frame_reset(s->frame_out);
 
-	if (frame_cmd_set(s->frame_out, "ABORT")) {
-		return -1;
-	}
+    if (frame_cmd_set(s->frame_out, "ABORT")) {
+        return -1;
+    }
 
-	if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
-		return -1;
-	}
+    if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
+        return -1;
+    }
 
-	if (frame_write(s->broker_fd, s->frame_out) < 0) {
-		s->run = 0;
-		return -1;
-	}
-	
-	clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+    if (frame_write(s->broker_fd, s->frame_out) < 0) {
+        s->run = 0;
+        return -1;
+    }
 
-	return 0;
+    clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+
+    return 0;
 }
 
 int stomp_ack(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs)
 {
-	switch(s->protocol) {
-		case SPL_12:
-			if (!hdr_get(hdrc, hdrs, "id")) {
-				errno = EINVAL;
-				return -1;
-			}
-			break;
-		case SPL_11:
-			if (!hdr_get(hdrc, hdrs, "message-id")) {
-				errno = EINVAL;
-				return -1;
-			}
-			if (!hdr_get(hdrc, hdrs, "subscription")) {
-				errno = EINVAL;
-				return -1;
-			}
-			break;
-		default: /* SPL_10 */
-			if (!hdr_get(hdrc, hdrs, "message-id")) {
-				errno = EINVAL;
-				return -1;
-			}
-	}
+    switch(s->protocol) {
+    case SPL_12:
+        if (!hdr_get(hdrc, hdrs, "id")) {
+            errno = EINVAL;
+            return -1;
+        }
+        break;
+    case SPL_11:
+        if (!hdr_get(hdrc, hdrs, "message-id")) {
+            errno = EINVAL;
+            return -1;
+        }
+        if (!hdr_get(hdrc, hdrs, "subscription")) {
+            errno = EINVAL;
+            return -1;
+        }
+        break;
+    default: /* SPL_10 */
+        if (!hdr_get(hdrc, hdrs, "message-id")) {
+            errno = EINVAL;
+            return -1;
+        }
+    }
 
-	
-	frame_reset(s->frame_out);
 
-	if (frame_cmd_set(s->frame_out, "ACK")) {
-		return -1;
-	}
+    frame_reset(s->frame_out);
 
-	if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
-		return -1;
-	}
+    if (frame_cmd_set(s->frame_out, "ACK")) {
+        return -1;
+    }
 
-	if (frame_write(s->broker_fd, s->frame_out) < 0) {
-		s->run = 0;
-		return -1;
-	}
-	
-	clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+    if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
+        return -1;
+    }
 
-	return 0;
+    if (frame_write(s->broker_fd, s->frame_out) < 0) {
+        s->run = 0;
+        return -1;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+
+    return 0;
 }
 
 int stomp_nack(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs)
 {
-	switch(s->protocol) {
-		case SPL_12:
-			if (!hdr_get(hdrc, hdrs, "id")) {
-				errno = EINVAL;
-				return -1;
-			}
-			break;
-		case SPL_11:
-			if (!hdr_get(hdrc, hdrs, "message-id")) {
-				errno = EINVAL;
-				return -1;
-			}
-			if (!hdr_get(hdrc, hdrs, "subscription")) {
-				errno = EINVAL;
-				return -1;
-			}
-			break;
-		default: /* SPL_10 */
-			errno = EINVAL;
-			return -1;
-	}
+    switch(s->protocol) {
+    case SPL_12:
+        if (!hdr_get(hdrc, hdrs, "id")) {
+            errno = EINVAL;
+            return -1;
+        }
+        break;
+    case SPL_11:
+        if (!hdr_get(hdrc, hdrs, "message-id")) {
+            errno = EINVAL;
+            return -1;
+        }
+        if (!hdr_get(hdrc, hdrs, "subscription")) {
+            errno = EINVAL;
+            return -1;
+        }
+        break;
+    default: /* SPL_10 */
+        errno = EINVAL;
+        return -1;
+    }
 
-	frame_reset(s->frame_out);
+    frame_reset(s->frame_out);
 
-	if (frame_cmd_set(s->frame_out, "NACK")) {
-		return -1;
-	}
-	
-	if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
-		return -1;
-	}
+    if (frame_cmd_set(s->frame_out, "NACK")) {
+        return -1;
+    }
 
-	if (frame_write(s->broker_fd, s->frame_out) < 0) {
-		s->run = 0;
-		return -1;
-	}
-	
-	clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+    if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
+        return -1;
+    }
 
-	return 0;
+    if (frame_write(s->broker_fd, s->frame_out) < 0) {
+        s->run = 0;
+        return -1;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+
+    return 0;
 }
 
 int stomp_commit(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs)
 {
-	if (!hdr_get(hdrc, hdrs, "transaction")) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!hdr_get(hdrc, hdrs, "transaction")) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	frame_reset(s->frame_out);
+    frame_reset(s->frame_out);
 
-	if (frame_cmd_set(s->frame_out, "COMMIT")) {
-		return -1;
-	}
+    if (frame_cmd_set(s->frame_out, "COMMIT")) {
+        return -1;
+    }
 
-	if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
-		return -1;
-	}
+    if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
+        return -1;
+    }
 
-	if (frame_write(s->broker_fd, s->frame_out) < 0) {
-		s->run = 0;
-		return -1;
-	}
-	
-	clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+    if (frame_write(s->broker_fd, s->frame_out) < 0) {
+        s->run = 0;
+        return -1;
+    }
 
-	return 0;
+    clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+
+    return 0;
 }
 
 int stomp_send(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs, void *body, size_t body_len)
 {
-	char buf[MAXBUFLEN];
-	const char *len;
+    char buf[MAXBUFLEN];
+    const char *len;
 
-	if (!hdr_get(hdrc, hdrs, "destination")) {
-		errno = EINVAL;
-		return -1;
-	}
+    if (!hdr_get(hdrc, hdrs, "destination")) {
+        errno = EINVAL;
+        return -1;
+    }
 
-	frame_reset(s->frame_out);
+    frame_reset(s->frame_out);
 
-	if (frame_cmd_set(s->frame_out, "SEND")) {
-		return -1;
-	}
-	
-	// frames SHOULD include a content-length
-	len = hdr_get(hdrc, hdrs, "content-length");
-	if (!len) {
-		snprintf(buf, MAXBUFLEN, "%lu", (unsigned long)body_len);
-		if (frame_hdr_add(s->frame_out, "content-length", buf)) {
-			return -1;
-		}
-	}
+    if (frame_cmd_set(s->frame_out, "SEND")) {
+        return -1;
+    }
 
-	if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
-		return -1;
-	}
+    // frames SHOULD include a content-length
+    len = hdr_get(hdrc, hdrs, "content-length");
+    if (!len) {
+        snprintf(buf, MAXBUFLEN, "%lu", (unsigned long)body_len);
+        if (frame_hdr_add(s->frame_out, "content-length", buf)) {
+            return -1;
+        }
+    }
 
-	if (frame_body_set(s->frame_out, body, body_len)) {
-		return -1;
-	}
-	
-	if (frame_write(s->broker_fd, s->frame_out) < 0) {
-		s->run = 0;
-		return -1;
-	}
-	
-	clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+    if (frame_hdrs_add(s->frame_out, hdrc, hdrs)) {
+        return -1;
+    }
 
-	return 0;
+    if (frame_body_set(s->frame_out, body, body_len)) {
+        return -1;
+    }
+
+    if (frame_write(s->broker_fd, s->frame_out) < 0) {
+        s->run = 0;
+        return -1;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &s->last_write);
+
+    return 0;
 }
 
-static void on_connected(stomp_session_t *s) 
-{ 
-	struct stomp_ctx_connected e;
-	frame_t *f = s->frame_in;
-	unsigned long x, y;
-	const char *h;
-	size_t hdrc;
-	const struct stomp_hdr *hdrs;
-	enum stomp_prot v;
+int stomp_send_h(stomp_session_t *s,
+                 const char *destination,
+                 const struct stomp_hdr *optional_hdrs,
+                 const char *text
+                )
+{
+    if (!s) {
+        errstr_set("null param 's'");
+        return -1;
+    }
 
-	hdrc = frame_hdrs_get(f, &hdrs);
-	h = hdr_get(hdrc, hdrs, "version");
-	if (h && !parse_version(h, &v)) {
-		s->protocol = v;
-	}
+    if (!destination) {
+        errstr_set("null param 'destination'");
+        return -1;
+    }
 
-	h = hdr_get(hdrc, hdrs, "heart-beat");
-	if (h && !parse_heartbeat(h, &x, &y)) {
-		if (!s->client_hb || !y) {
-			s->client_hb = 0;
-		} else {
-			s->client_hb = s->client_hb > y ? s->client_hb : y;
-		}
+    if (!text) {
+        errstr_set("null param 'text'");
+        return -1;
+    }
 
-		if (!s->broker_hb || !x) {
-			s->broker_hb = 0;
-		} else {
-			s->broker_hb = s->broker_hb > x ? s->broker_hb : x;
-		}
-	} else {
-		s->client_hb = 0;
-		s->broker_hb = 0;
-	}
+    // constuct hdrs
+    struct stomp_hdr hdrs[MAX_NUM_HEADER];
+    size_t hdr_i = 0;
+    memset(hdrs, 0, sizeof(hdrs));
 
-	if (!s->callbacks.connected) {
-		return;
-	}
+    hdrs[hdr_i++] = (struct stomp_hdr) {"destination", destination};
+    hdrs[hdr_i++] = (struct stomp_hdr) {"content-type", "text/plain"};
 
-	e.hdrc = hdrc;
-	e.hdrs = hdrs;
+    if (optional_hdrs) {
+        const struct stomp_hdr *opt_hdr = optional_hdrs;
+        while (opt_hdr->key && hdr_i < MAX_NUM_HEADER) {
+            hdrs[hdr_i++] = (struct stomp_hdr) {
+                opt_hdr->key, opt_hdr->val
+            };
+            opt_hdr++;
+        }
+    }
 
-	s->callbacks.connected(s, &e, s->ctx);
+    // delegate
+    return stomp_send(s, hdr_i, hdrs, (void *)text, strlen(text));
 }
 
-static void on_receipt(stomp_session_t *s) 
-{ 
-	struct stomp_ctx_receipt e;
-	frame_t *f = s->frame_in;
 
-	if (!s->callbacks.receipt) {
-		return;
-	}
+static void on_connected(stomp_session_t *s)
+{
+    struct stomp_ctx_connected e;
+    frame_t *f = s->frame_in;
+    unsigned long x, y;
+    const char *h;
+    size_t hdrc;
+    const struct stomp_hdr *hdrs;
+    enum stomp_prot v;
 
-	e.hdrc = frame_hdrs_get(f, &e.hdrs);
+    hdrc = frame_hdrs_get(f, &hdrs);
+    h = hdr_get(hdrc, hdrs, "version");
+    if (h && !parse_version(h, &v)) {
+        s->protocol = v;
+    }
 
-	s->callbacks.receipt(s, &e, s->ctx);
+    h = hdr_get(hdrc, hdrs, "heart-beat");
+    if (h && !parse_heartbeat(h, &x, &y)) {
+        if (!s->client_hb || !y) {
+            s->client_hb = 0;
+        } else {
+            s->client_hb = s->client_hb > y ? s->client_hb : y;
+        }
+
+        if (!s->broker_hb || !x) {
+            s->broker_hb = 0;
+        } else {
+            s->broker_hb = s->broker_hb > x ? s->broker_hb : x;
+        }
+    } else {
+        s->client_hb = 0;
+        s->broker_hb = 0;
+    }
+
+    if (!s->callbacks.connected) {
+        return;
+    }
+
+    e.hdrc = hdrc;
+    e.hdrs = hdrs;
+
+    s->callbacks.connected(s, &e, s->ctx);
 }
 
-static void on_error(stomp_session_t *s) 
-{ 
-	struct stomp_ctx_error e;
-	frame_t *f = s->frame_in;
+static void on_receipt(stomp_session_t *s)
+{
+    struct stomp_ctx_receipt e;
+    frame_t *f = s->frame_in;
 
-	if (!s->callbacks.error) {
-		return;
-	}
+    if (!s->callbacks.receipt) {
+        return;
+    }
 
-	e.hdrc = frame_hdrs_get(f, &e.hdrs);
-	e.body_len = frame_body_get(f, &e.body);
+    e.hdrc = frame_hdrs_get(f, &e.hdrs);
 
-	s->callbacks.error(s, &e, s->ctx);
+    s->callbacks.receipt(s, &e, s->ctx);
 }
 
-static void on_message(stomp_session_t *s) 
-{ 
-	struct stomp_ctx_message e;
-	frame_t *f = s->frame_in;
+static void on_error(stomp_session_t *s)
+{
+    struct stomp_ctx_error e;
+    frame_t *f = s->frame_in;
 
-	if (!s->callbacks.message) {
-		return;
-	}
-	
-	e.hdrc = frame_hdrs_get(f, &e.hdrs);
-	e.body_len = frame_body_get(f, &e.body);
+    if (!s->callbacks.error) {
+        return;
+    }
 
-	s->callbacks.message(s, &e, s->ctx);
+    e.hdrc = frame_hdrs_get(f, &e.hdrs);
+    e.body_len = frame_body_get(f, &e.body);
+
+    s->callbacks.error(s, &e, s->ctx);
+}
+
+static void on_message(stomp_session_t *s)
+{
+    struct stomp_ctx_message e;
+    frame_t *f = s->frame_in;
+
+    if (!s->callbacks.message) {
+        return;
+    }
+
+    e.hdrc = frame_hdrs_get(f, &e.hdrs);
+    e.body_len = frame_body_get(f, &e.body);
+
+    s->callbacks.message(s, &e, s->ctx);
 }
 
 static int on_server_cmd(stomp_session_t *s)
 {
-	int err;
-	const char *cmd;
-	size_t cmd_len;
-	frame_t *f = s->frame_in;
+    int err;
+    const char *cmd;
+    size_t cmd_len;
+    frame_t *f = s->frame_in;
 
-	frame_reset(f);
+    frame_reset(f);
 
-	err = frame_read(s->broker_fd, f);
-	if (err) {
-		return -1;
-	}
-	
-	cmd_len = frame_cmd_get(f, &cmd);
-	/* heart-beat */
-	if (!cmd_len) {
-		return 0;
-	}
+    err = frame_read(s->broker_fd, f);
+    if (err) {
+        return -1;
+    }
 
-	if (!strncmp(cmd, "CONNECTED", cmd_len)) {
-		on_connected(s);
-	} else if (!strncmp(cmd, "ERROR", cmd_len)) {
-		on_error(s);
-	} else if (!strncmp(cmd, "RECEIPT", cmd_len)) {
-		on_receipt(s);
-	} else if (!strncmp(cmd, "MESSAGE", cmd_len)) {
-		on_message(s);
-	} else {
-		return -1;
-	}
-	
-	return 0;
+    cmd_len = frame_cmd_get(f, &cmd);
+    /* heart-beat */
+    if (!cmd_len) {
+        return 0;
+    }
+
+    if (!strncmp(cmd, "CONNECTED", cmd_len)) {
+        on_connected(s);
+    } else if (!strncmp(cmd, "ERROR", cmd_len)) {
+        on_error(s);
+    } else if (!strncmp(cmd, "RECEIPT", cmd_len)) {
+        on_receipt(s);
+    } else if (!strncmp(cmd, "MESSAGE", cmd_len)) {
+        on_message(s);
+    } else {
+        return -1;
+    }
+
+    return 0;
 }
 
 int stomp_run(stomp_session_t *s)
 {
-	fd_set rd;
-	int r;
-	struct timeval tv;
-	unsigned long t; /* select timeout in milliseconds */
-	struct timespec now;
-	unsigned long elapsed;
+    fd_set rd;
+    int r;
+    struct timeval tv;
+    unsigned long t; /* select timeout in milliseconds */
+    struct timespec now;
+    unsigned long elapsed;
 
-	if (!s->broker_hb && !s->client_hb) {
-		t = 1000;
-	} else if (s->broker_hb && s->client_hb) {
-		t = s->broker_hb < s->client_hb ? s->broker_hb : s->client_hb;
-	} else {
-		t = s->broker_hb > s->client_hb ? s->broker_hb : s->client_hb;
-	}
-	
-	tv.tv_sec = t / 1000;
-	tv.tv_usec = (t % 1000) * 1000;
-	
-	while(s->run) {
-		FD_ZERO(&rd);
-		FD_SET(s->broker_fd, &rd);
-	
-		r = select(s->broker_fd + 1, &rd, 0, 0, &tv);
-		if(r < 0 && errno != EINTR) {
-			goto stomp_run_error;
-		} 
-	
-		if(r && FD_ISSET(s->broker_fd, &rd)) {
-			clock_gettime(CLOCK_MONOTONIC, &s->last_read);
-			s->broker_timeouts = 0;
-			if (on_server_cmd(s)) {
-				goto stomp_run_error;
-			}
-		}
+    if (!s->broker_hb && !s->client_hb) {
+        t = 1000;
+    } else if (s->broker_hb && s->client_hb) {
+        t = s->broker_hb < s->client_hb ? s->broker_hb : s->client_hb;
+    } else {
+        t = s->broker_hb > s->client_hb ? s->broker_hb : s->client_hb;
+    }
 
-		if (s->callbacks.user) {
-			s->callbacks.user(s, NULL, s->ctx);
-		}
 
-		if (s->client_hb || s->broker_hb) {
-			clock_gettime(CLOCK_MONOTONIC, &now);
-		}
-		
-		if (s->broker_hb) {
-			elapsed = (now.tv_sec - s->last_read.tv_sec) * 1000 + \
-				  (now.tv_nsec - s->last_read.tv_nsec) / 1000000;
+    while(s->run) {
+        FD_ZERO(&rd);
+        FD_SET(s->broker_fd, &rd);
 
-			if (elapsed > s->broker_hb) {
-				memcpy(&s->last_read, &now, sizeof(s->last_write));
-				s->broker_timeouts++;
-			}
+        /* re-init timeout
+           from manpage<select>: On Linux, select() modifies timeout to reflect the amount of time not slept; most other implementations do not do this.
+         */
+        tv.tv_sec = t / 1000;
+        tv.tv_usec = (t % 1000) * 1000;
 
-			if (s->broker_timeouts > MAXBROKERTMOUTS) {
-				errno = ETIMEDOUT;
-				goto stomp_run_error;
-			}
-		}
-		
-		if (s->client_hb) {
-			elapsed = (now.tv_sec - s->last_write.tv_sec) * 1000 + \
-				  (now.tv_nsec - s->last_write.tv_nsec) / 1000000;
+        r = select(s->broker_fd + 1, &rd, 0, 0, &tv);
+        if(r < 0 && errno != EINTR) {
+            goto stomp_run_error;
+        }
 
-			if (elapsed > s->client_hb) {
-				memcpy(&s->last_write, &now, sizeof(s->last_write));
-				if (write(s->broker_fd, "\n", 1) == -1) {
-					goto stomp_run_error;
-				}
-			}
-		}
-	}
+        if(r && FD_ISSET(s->broker_fd, &rd)) {
+            clock_gettime(CLOCK_MONOTONIC, &s->last_read);
+            s->broker_timeouts = 0;
+            if (on_server_cmd(s)) {
+                goto stomp_run_error;
+            }
+        }
 
-	(void)close(s->broker_fd);
-	return 0;
+        if (s->callbacks.user) {
+            s->callbacks.user(s, NULL, s->ctx);
+        }
+
+        if (s->client_hb || s->broker_hb) {
+            clock_gettime(CLOCK_MONOTONIC, &now);
+        }
+
+        if (s->broker_hb) {
+            elapsed = (now.tv_sec - s->last_read.tv_sec) * 1000 + \
+                      (now.tv_nsec - s->last_read.tv_nsec) / 1000000;
+
+            if (elapsed > s->broker_hb) {
+                memcpy(&s->last_read, &now, sizeof(s->last_write));
+                s->broker_timeouts++;
+            }
+
+            if (s->broker_timeouts > MAXBROKERTMOUTS) {
+                errno = ETIMEDOUT;
+                goto stomp_run_error;
+            }
+        }
+
+        if (s->client_hb) {
+            elapsed = (now.tv_sec - s->last_write.tv_sec) * 1000 + \
+                      (now.tv_nsec - s->last_write.tv_nsec) / 1000000;
+
+            if (elapsed > s->client_hb) {
+                memcpy(&s->last_write, &now, sizeof(s->last_write));
+                if (write(s->broker_fd, "\n", 1) == -1) {
+                    goto stomp_run_error;
+                }
+            }
+        }
+    }
+
+    (void)close(s->broker_fd);
+    return 0;
 
 stomp_run_error:
 
-	(void)close(s->broker_fd);
-	return -1;
+    (void)close(s->broker_fd);
+    return -1;
 }
 

--- a/src/stomp.h
+++ b/src/stomp.h
@@ -1,6 +1,8 @@
 /*
  * Copyright 2013 Evgeni Dobrev <evgeni_dobrev@developer.bg>
  *
+ *      2014-10-14   modify    Larry Wu<rulerson@gmail.com>    add some heper functions
+ *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -23,293 +25,377 @@
 extern "C" {
 #endif
 
-/**
- * An opaque STOMP sesstion handle
- *
- * @see stomp_session_new()
- * @see stomp_session_free()
- */
-typedef struct _stomp_session stomp_session_t;
+    /**
+     * An opaque STOMP sesstion handle
+     *
+     * @see stomp_session_new()
+     * @see stomp_session_free()
+     */
+    typedef struct _stomp_session stomp_session_t;
 
-/**
- * Structure representing a STOMP header entry
- *
- * All functions which accept headers as a parameter use this, and 
- * also all context structures.
- */
-struct stomp_hdr {
-	const char *key; /**< null terminated string */
-	const char *val; /**< null terminated string */
-};
+    /**
+     * Structure representing a STOMP header entry
+     *
+     * All functions which accept headers as a parameter use this, and
+     * also all context structures.
+     */
+    struct stomp_hdr {
+        const char *key; /**< null terminated string */
+        const char *val; /**< null terminated string */
+    };
 
-/**
- * This structure is provided to the client code
- * which registered a callback for SCB_CONNECTED.
- */
-struct stomp_ctx_connected {
-	size_t hdrc; /**< number of headers */
-	const struct stomp_hdr *hdrs; /**< pointer to an array of headers */
-};
+    /**
+     * This structure is provided to the client code
+     * which registered a callback for SCB_CONNECTED.
+     */
+    struct stomp_ctx_connected {
+        size_t hdrc; /**< number of headers */
+        const struct stomp_hdr *hdrs; /**< pointer to an array of headers */
+    };
 
-/**
- * This structure is provided to the client code
- * which registered a callback for SCB_RECEIPT.
- */
-struct stomp_ctx_receipt {
-	size_t hdrc; /**< number of headers */
-	const struct stomp_hdr *hdrs; /**< pointer to an array of headers */
-};
-
-
-/**
- * This structure is provided to the client code
- * which registered a callback for SCB_ERROR.
- */
-struct stomp_ctx_error { 
-	size_t hdrc; /**< number of headers */
-	const struct stomp_hdr *hdrs; /**< pointer to an array of headers */
-	const void *body; /**< pointer to the body of the message */
-	size_t body_len; /**< length of body in bytes */
-};
-
-/**
- * This structure is provided to the client code
- * which registered a callback for SCB_MESSAGE.
- */
-struct stomp_ctx_message {
-	size_t hdrc; /**< number of headers */
-	const struct stomp_hdr *hdrs; /**< pointer to an array of headers */
-	const void *body; /**< pointer to the body of the message */
-	size_t body_len; /**< length of body in bytes */
-};
+    /**
+     * This structure is provided to the client code
+     * which registered a callback for SCB_RECEIPT.
+     */
+    struct stomp_ctx_receipt {
+        size_t hdrc; /**< number of headers */
+        const struct stomp_hdr *hdrs; /**< pointer to an array of headers */
+    };
 
 
-/**
- * List of events the client code can register 
- * a callback for.
- *
- * Aside from the server responses the client
- * can also register for a user callback (SCB_USER). The callback
- * will be called within every itteration of stomp_run(). 
- * The amount of time between the calls is set to 1 second when no 
- * heart-beat header is provided. Otherwise it wil get called 
- * with the smallest timeneeded to satisfy the requuired heart-beats.
- *
- * @seen stomp_callback_set
- * @seen stomp_callback_del
- */
-enum stomp_cb_type {
-	SCB_CONNECTED, /**< server sended CONNECTED */
-	SCB_ERROR, /**< server sended ERROR */
-	SCB_MESSAGE, /**< server sended MESSAGE  */
-	SCB_RECEIPT, /**< server sended RECEIPT  */
-	SCB_USER /**< user slot */
-};
+    /**
+     * This structure is provided to the client code
+     * which registered a callback for SCB_ERROR.
+     */
+    struct stomp_ctx_error {
+        size_t hdrc; /**< number of headers */
+        const struct stomp_hdr *hdrs; /**< pointer to an array of headers */
+        const void *body; /**< pointer to the body of the message */
+        size_t body_len; /**< length of body in bytes */
+    };
 
-typedef void(*stomp_cb_t)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
+    /**
+     * This structure is provided to the client code
+     * which registered a callback for SCB_MESSAGE.
+     */
+    struct stomp_ctx_message {
+        size_t hdrc; /**< number of headers */
+        const struct stomp_hdr *hdrs; /**< pointer to an array of headers */
+        const void *body; /**< pointer to the body of the message */
+        size_t body_len; /**< length of body in bytes */
+    };
 
-/**
- * Register a callback when a particular event occurs.
- *
- * @param s pointer to a session handle
- * @param type type of event to register for
- * @param cb callback to register
- */
-void stomp_callback_set(stomp_session_t *s, enum stomp_cb_type type, stomp_cb_t cb);
 
-/**
- * Delete callback for a particular event.
- *
- * @param s Pointer to a session handle
- * @param type Type of event to register for
- * @param cb Callback to register
- */
-void stomp_callback_del(stomp_session_t *s, enum stomp_cb_type type);
+    /**
+     * List of events the client code can register
+     * a callback for.
+     *
+     * Aside from the server responses the client
+     * can also register for a user callback (SCB_USER). The callback
+     * will be called within every itteration of stomp_run().
+     * The amount of time between the calls is set to 1 second when no
+     * heart-beat header is provided. Otherwise it wil get called
+     * with the smallest timeneeded to satisfy the requuired heart-beats.
+     *
+     * @seen stomp_callback_set
+     * @seen stomp_callback_del
+     */
+    enum stomp_cb_type {
+        SCB_CONNECTED, /**< server sended CONNECTED */
+        SCB_ERROR, /**< server sended ERROR */
+        SCB_MESSAGE, /**< server sended MESSAGE  */
+        SCB_RECEIPT, /**< server sended RECEIPT  */
+        SCB_USER /**< user slot */
+    };
 
-/**
- * Create a STOMP session handle.
- *
- * @param callbacks Callbacks to run when a certain STOMP event occurs.
- * @param session_ctx A data pointer to pass to the callback.
- * @return a newly allocated session or NULL on errors.
- *
- * @see stomp_session_free()
- */
-stomp_session_t *stomp_session_new(void *session_ctx);
+    typedef void(*stomp_cb_t)(stomp_session_t *s, void *callback_ctx, void *session_ctx);
 
-/**
- * Delete a STOMP session handle.
- *
- * @param session Session handle to delete.
- *
- * @see stomp_session_new()
- */
-void stomp_session_free(stomp_session_t *s);
+    /**
+     * Register a callback when a particular event occurs.
+     *
+     * @param s pointer to a session handle
+     * @param type type of event to register for
+     * @param cb callback to register
+     */
+    void stomp_callback_set(stomp_session_t *s, enum stomp_cb_type type, stomp_cb_t cb);
 
-/**
- * Connect to a STOMP broker.
- *
- * Headers parameter MUST contain the headers required by the specification.
- * Note that in order to get notified of the server responses you must
- * register the appropriate handler and call stomp_run()
- *
- * @param s Pointer to a session handle.
- * @param host Hostname to connect to.
- * @param service Service of port to connect to.
- * @param hdrc Number of STOMP headers.
- * @param hdrs Pointer to an array of STOMP headers.
- *
- * @return 0 on success; negative on error and errno is set appropriately.
- */
-int stomp_connect(stomp_session_t *s, const char *host, const char *service, size_t hdrc, const struct stomp_hdr *hdrs);
+    /**
+     * Delete callback for a particular event.
+     *
+     * @param s Pointer to a session handle
+     * @param type Type of event to register for
+     */
+    void stomp_callback_del(stomp_session_t *s, enum stomp_cb_type type);
 
-/**
- * Disconnect from a STOMP broker.
- *
- * @param s Pointer to a session handle.
- * @param hdrc Number of STOMP headers.
- * @param hdrs Pointer to an array of STOMP headers.
- *
- * @return 0 on success; negative on error and errno is set appropriately.
- */
-int stomp_disconnect(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
+    /**
+     * Create a STOMP session handle.
+     *
+     * @param session_ctx A data pointer to pass to the callback.
+     *
+     * @return a newly allocated session or NULL on errors.
+     *
+     * @see stomp_session_free()
+     */
+    stomp_session_t *stomp_session_new(void *session_ctx);
 
-/**
- * Subscribe to a destination.
- *
- * Headers MUST contain a "destination" header key.
- * Headers SHOULD contain an "id" header with unique key.
- * Headers MAY contan an "ack" header. If none is provided "ack:auto" will be sent.
- *
- * If no "id" header is provided one will be generated. The return value is the key, and it must be 
- * fed to stomp_unsibsribe().
- *
- * Note that if an "id" header si provided no attempt will be made
- * to assure the uniqueness of the value.
- *
- * @param s Pointer to a session handle.
- * @param hdrc Number of STOMP headers.
- * @param hdrs Pointer to an array of STOMP headers.
- *
- * @return negative on error; or client_id to be used in stomp_unsubscribe()
-*/
-int stomp_subscribe(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
+    /**
+     * Delete a STOMP session handle.
+     *
+     * @param s Session handle to delete.
+     *
+     * @see stomp_session_new()
+     */
+    void stomp_session_free(stomp_session_t *s);
 
-/**
- * Unsubscribe from a destination.
- *
- * Headers MUST contain a "destination" header key.
- * For Stomp 1.1+, "id" header key per the specifications.  
- * client_id is the handle returned by stomp_subscribe()
- *
- * @param s Pointer to a session handle.
- * @param hdrc Number of STOMP headers.
- * @param hdrs Pointer to an array of STOMP headers.
- *
- * @return 0 on success; negative on error and errno is set appropriately.
- */
-int stomp_unsubscribe(stomp_session_t *s, int client_id, size_t hdrc, const struct stomp_hdr *hdrs);
+    /**
+     * Connect to a STOMP broker.
+     *
+     * Headers parameter MUST contain the headers required by the specification.
+     * Note that in order to get notified of the server responses you must
+     * register the appropriate handler and call stomp_run()
+     *
+     * @param s Pointer to a session handle.
+     * @param host Hostname to connect to.
+     * @param service Service of port to connect to.
+     * @param hdrc Number of STOMP headers.
+     * @param hdrs Pointer to an array of STOMP headers.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_connect(stomp_session_t *s, const char *host, const char *service, size_t hdrc, const struct stomp_hdr *hdrs);
 
-/**
- * Start a transaction.
- *
- * Headers MUST contain a "transaction" header key 
- * with a value that is not an empty string.
- *
- * @param s Pointer to a session handle.
- * @param hdrc Number of STOMP headers.
- * @param hdrs Pointer to an array of STOMP headers.
- *
- * @return 0 on success; negative on error and errno is set appropriately.
- */
-int stomp_begin(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
 
-/**
- * Abort a transaction.
- *
- * Headers MUST contain a "transaction" header key 
- * with a value that is not an empty string.
- *
- * @param s Pointer to a session handle.
- * @param hdrc Number of STOMP headers.
- * @param hdrs Pointer to an array of STOMP headers.
- *
- * @return 0 on success; negative on error and errno is set appropriately.
- */
-int stomp_abort(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
+    /**
+     * Connect to a STOMP broker. Wrapper of stomp_connect.
+     *
+     * @param s Pointer to a session handle.
+     * @param host Hostname to connect to. Default to 'localhost' if NULL.
+     * @param service Service of port to connect to. Default to '61613' if NULL.
+     * @param accept_version Header of 'accept-version'. Default to '1.2' if NULL.
+     * @param v_host Header of 'host'. Default to first host if NULL.
+     * @param login Header of 'login', username. Default to 'admin' if NULL.
+     * @param passcode Header of 'passcode', password. Default to 'password' if NULL.
+     * @param heart_beat Header of 'heart-beat'. Default to '5000,10000' (miliseconds) if NULL.
+     * @param optional_hdrs Pointer to an NULL terminated array of STOMP headers, optional, can be NULL.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_connect_h(stomp_session_t *s,
+                        const char *host,
+                        const char *service,
+                        const char *accept_version,
+                        const char *v_host,
+                        const char *login,
+                        const char *passcode,
+                        const char *heart_beat,
+                        const struct stomp_hdr *optional_hdrs
+                       );
+    /**
+     * Disconnect from a STOMP broker.
+     *
+     * @param s Pointer to a session handle.
+     * @param hdrc Number of STOMP headers.
+     * @param hdrs Pointer to an array of STOMP headers.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_disconnect(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
 
-/**
- * Acknowledge a message.
- *
- * Stomp 1.0 Headers MUST contain a "message-id" header key.
- * Stomp 1.1 Headers must contain a "message-id" key and a "subscription" header key.
- * Stomp 1.2 Headers must contain a unique "id" header key.
- *
- * @param s Pointer to a session handle.
- * @param hdrc Number of STOMP headers.
- * @param hdrs Pointer to an array of STOMP headers.
- *
- * @return 0 on success; negative on error and errno is set appropriately.
- */
-int stomp_ack(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
+    /**
+     * Disconnect from a STOMP broker. Wrapper of stomp_disconnect.
+     *
+     * @param s Pointer to a session handle.
+     * @param optional_hdrs Pointer to an NULL terminated array of STOMP headers, optional, can be NULL.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_disconnect_h(stomp_session_t *s,
+                           const struct stomp_hdr *optional_hdrs);
 
-/**
- * Nack a message.
- *
- * Stomp 1.1 Headers must contain a "message-id" key and a "subscription" header key.
- * Stomp 1.2 Headers must contain a unique "id" header key.
- * Disallowed for an established STOMP 1.0 connection.
- *
- * @param s Pointer to a session handle.
- * @param hdrc Number of STOMP headers.
- * @param hdrs Pointer to an array of STOMP headers.
- *
- * @return 0 on success; negative on error and errno is set appropriately.
- */
-int stomp_nack(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
+    /**
+     * Subscribe to a destination.
+     *
+     * Headers MUST contain a "destination" header key.
+     * Headers SHOULD contain an "id" header with unique key.
+     * Headers MAY contan an "ack" header. If none is provided "ack:auto" will be sent.
+     *
+     * If no "id" header is provided one will be generated. The return value is the key, and it must be
+     * fed to stomp_unsibsribe().
+     *
+     * Note that if an "id" header si provided no attempt will be made
+     * to assure the uniqueness of the value.
+     *
+     * @param s Pointer to a session handle.
+     * @param hdrc Number of STOMP headers.
+     * @param hdrs Pointer to an array of STOMP headers.
+     *
+     * @return negative on error; or client_id to be used in stomp_unsubscribe()
+     */
+    int stomp_subscribe(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
 
-/**
- * Commit a transaction.
- *
- * Headers MUST contain a "transaction" header key 
- * with a value that is not an empty string.
- *
- * @param s Pointer to a session handle.
- * @param hdrc Number of STOMP headers.
- * @param hdrs Pointer to an array of STOMP headers.
- *
- * @return 0 on success; negative on error and errno is set appropriately.
- */
-int stomp_commit(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
+    /**
+     * Subscribe to a destination. Wrapper of stomp_subscribe.
+     *
+     * @param s Pointer to a session handle.
+     * @param id Header of 'id'. Default to Auto-generated if NULL.
+     * @param id Header of 'destination', message will send to it. No Default value.
+     * @param id Header of 'ack'. Default to 'auto'.
+     * @param optional_hdrs Pointer to an array of STOMP headers, optional, can be NULL.
+     *
+     * @return negative on error; or client_id to be used in stomp_unsubscribe()
+     */
+    int stomp_subscribe_h2(stomp_session_t *s,
+                           const char *id,
+                           const char *destination,
+                           const char *ack,
+                           const struct stomp_hdr *optional_hdrs);
 
-/**
- * Send a message.
- *
- * Headers MUST contain a "destination" header key.
- * Headers SHOULD contain a "content-type" header key.
- * Header "content-length" will be set according to body_len parameter.
- *
- * @param s Pointer to a session handle.
- * @param hdrc Number of STOMP headers.
- * @param hdrs Pointer to an array of STOMP headers.
- * @param body Pointer to the message body.
- * @param body_len Length of the body in bytes.
- *
- * @return 0 on success; negative on error and errno is set appropriately.
- */
-int stomp_send(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs, void *body, size_t body_len);
+    /**
+     * Subscribe to a destination. Wrapper of stomp_subscribe_h2.
+     *
+     * @param s Pointer to a session handle.
+     * @param id Header of 'destination', message will send to it. No Default value.
+     * @param optional_hdrs Pointer to an array of STOMP headers, optional, can be NULL.
+     *
+     * @return negative on error; or client_id to be used in stomp_unsubscribe()
+     */
+    int stomp_subscribe_h(stomp_session_t *s,
+                          const char *destination,
+                          const struct stomp_hdr *optional_hdrs);
 
-/**
- * Runs the library main loop.
- * 
- * This function will not return until either he server closes the 
- * connection, or the client calls stomp_disconnect()
- *
- * @param s Pointer to a session handle.
- *
- * @return 0 on success; negative on error and errno is set appropriately
- */
-int stomp_run(stomp_session_t *s);
+    /**
+     * Unsubscribe from a destination.
+     *
+     * Headers MUST contain a "destination" header key.
+     * For Stomp 1.1+, "id" header key per the specifications.
+     * client_id is the handle returned by stomp_subscribe()
+     *
+     * @param s Pointer to a session handle.
+     * @param hdrc Number of STOMP headers.
+     * @param hdrs Pointer to an array of STOMP headers.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_unsubscribe(stomp_session_t *s, int client_id, size_t hdrc, const struct stomp_hdr *hdrs);
+
+    /**
+     * Start a transaction.
+     *
+     * Headers MUST contain a "transaction" header key
+     * with a value that is not an empty string.
+     *
+     * @param s Pointer to a session handle.
+     * @param hdrc Number of STOMP headers.
+     * @param hdrs Pointer to an array of STOMP headers.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_begin(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
+
+    /**
+     * Abort a transaction.
+     *
+     * Headers MUST contain a "transaction" header key
+     * with a value that is not an empty string.
+     *
+     * @param s Pointer to a session handle.
+     * @param hdrc Number of STOMP headers.
+     * @param hdrs Pointer to an array of STOMP headers.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_abort(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
+
+    /**
+     * Acknowledge a message.
+     *
+     * Stomp 1.0 Headers MUST contain a "message-id" header key.
+     * Stomp 1.1 Headers must contain a "message-id" key and a "subscription" header key.
+     * Stomp 1.2 Headers must contain a unique "id" header key.
+     *
+     * @param s Pointer to a session handle.
+     * @param hdrc Number of STOMP headers.
+     * @param hdrs Pointer to an array of STOMP headers.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_ack(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
+
+    /**
+     * Nack a message.
+     *
+     * Stomp 1.1 Headers must contain a "message-id" key and a "subscription" header key.
+     * Stomp 1.2 Headers must contain a unique "id" header key.
+     * Disallowed for an established STOMP 1.0 connection.
+     *
+     * @param s Pointer to a session handle.
+     * @param hdrc Number of STOMP headers.
+     * @param hdrs Pointer to an array of STOMP headers.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_nack(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
+
+    /**
+     * Commit a transaction.
+     *
+     * Headers MUST contain a "transaction" header key
+     * with a value that is not an empty string.
+     *
+     * @param s Pointer to a session handle.
+     * @param hdrc Number of STOMP headers.
+     * @param hdrs Pointer to an array of STOMP headers.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_commit(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs);
+
+    /**
+     * Send a message.
+     *
+     * Headers MUST contain a "destination" header key.
+     * Headers SHOULD contain a "content-type" header key.
+     * Header "content-length" will be set according to body_len parameter.
+     *
+     * @param s Pointer to a session handle.
+     * @param hdrc Number of STOMP headers.
+     * @param hdrs Pointer to an array of STOMP headers.
+     * @param body Pointer to the message body.
+     * @param body_len Length of the body in bytes.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_send(stomp_session_t *s, size_t hdrc, const struct stomp_hdr *hdrs, void *body, size_t body_len);
+
+    /**
+     * Send a text message. Wrapper of stomp_send.
+     *
+     * Header 'content-type' will be set to 'text/plain' always.
+     *
+     * @param s Pointer to a session handle.
+     * @param destination Header of 'destination'.
+     * @param optional_hdrs Pointer to an array of STOMP headers, optional, can be NULL.
+     * @param text Null terminated string, set to body.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately.
+     */
+    int stomp_send_h(stomp_session_t *s,
+                     const char *destination,
+                     const struct stomp_hdr *optional_hdrs,
+                     const char *text
+                    );
+
+    /**
+     * Runs the library main loop.
+     *
+     * This function will not return until either he server closes the
+     * connection, or the client calls stomp_disconnect()
+     *
+     * @param s Pointer to a session handle.
+     *
+     * @return 0 on success; negative on error and errno is set appropriately
+     */
+    int stomp_run(stomp_session_t *s);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
While testing this library, I found that, if the STOMP server is disconnected or disappears for some reason, the socket which the library sets up and uses is silently disconnected. If the application employing the library issues a write, in this circumstance, the application silently quits. This is due to the use of the POSIX write() function, which, by POSIX design, forces the invoking application to quit rather than lingering around when the output is no longer needed.

Instead, a very simple solution, is to replace the use of write() with the functionally equivalent POSIX function send(), which allows to specify flags, one of which is MSG_NOSIGNAL. This prevents SIGPIPE from being raised when the connection is broken, and puts the onus on the caller to detect that the write failed, which is, in fact how the function using this routine appeared to attempt to handle.
